### PR TITLE
use `--no-install-recommends` in `apt-get` in dockerfiles to save space

### DIFF
--- a/jnlp-slave/Dockerfile
+++ b/jnlp-slave/Dockerfile
@@ -5,7 +5,7 @@ ENV GIT_VERSION 2.27.0
 USER root
 
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get --no-install-recommends install -y \
     apt-transport-https \
     ca-certificates \
     curl \
@@ -36,7 +36,7 @@ RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
     $(lsb_release -cs) \
     stable" && \
     apt-get update && \
-    apt-get install -y \
+    apt-get --no-install-recommends install -y \
     docker-ce \
     docker-ce-cli \
     containerd.io && \


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>