### PR TITLE
change test jobs names to descrease it's length

### DIFF
--- a/jenkins-jobs/v1.2.1/longhorn-tests-ubuntu-amd64.yml
+++ b/jenkins-jobs/v1.2.1/longhorn-tests-ubuntu-amd64.yml
@@ -1,5 +1,5 @@
 - job:
-    name: v1.2.x-longhorn-tests-ubuntu-amd64
+    name: v1.2.x-lh-tests-ubuntu-amd64
     disabled: false
     project-type: pipeline
     folder: public/v1.2.x

--- a/jenkins-jobs/v1.2.1/longhorn-tests-ubuntu-arm64.yml
+++ b/jenkins-jobs/v1.2.1/longhorn-tests-ubuntu-arm64.yml
@@ -1,5 +1,5 @@
 - job:
-    name: v1.2.x-longhorn-tests-ubuntu-arm64
+    name: v1.2.x-lh-tests-ubuntu-arm64
     disabled: false
     project-type: pipeline
     folder: public/v1.2.x

--- a/jenkins-jobs/v1.2.1/longhorn-upgrade-tests-ubuntu-amd64.yml
+++ b/jenkins-jobs/v1.2.1/longhorn-upgrade-tests-ubuntu-amd64.yml
@@ -1,5 +1,5 @@
 - job:
-    name: v1.2.x-longhorn-upgrade-tests-ubuntu-amd64
+    name: v1.2.x-lh-upgrade-tests-ubuntu-amd64
     disabled: false
     project-type: pipeline
     folder: public/v1.2.x

--- a/jenkins-jobs/v1.2.1/longhorn-upgrade-tests-ubuntu-arm64.yml
+++ b/jenkins-jobs/v1.2.1/longhorn-upgrade-tests-ubuntu-arm64.yml
@@ -1,5 +1,5 @@
 - job:
-    name: v1.2.x-longhorn-upgrade-tests-ubuntu-arm64
+    name: v1.2.x-lh-upgrade-tests-ubuntu-arm64
     disabled: false
     project-type: pipeline
     folder: public/v1.2.x


### PR DESCRIPTION
job name is used as prefix to instances names, and names needs to be less than 64 characters to be valid.

Signed-off-by: Mohamed Eldafrawi <mohamed.eldafrawi@suse.com>