### PR TITLE
fix the auto trigger and add the variable at config file

### DIFF
--- a/jenkins-jobs/longhorn-tests-regression.yml
+++ b/jenkins-jobs/longhorn-tests-regression.yml
@@ -56,6 +56,10 @@
           default: false
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
+          name: BACKUP_STORE_TYPE
+          default: "nfs-and-s3"
+          description: "The valid values for this field are 'nfs', 's3' and 'nfs-and-s3'"
+      - string:
           name: LONGHORN_STABLE_VERSION
           default: "v1.1.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"

--- a/jenkins-jobs/master/longhorn-tests-rhel-amd64.yml
+++ b/jenkins-jobs/master/longhorn-tests-rhel-amd64.yml
@@ -48,6 +48,10 @@
           default: ""
           description: "pytest custom options to run specific tests (e.g -k test_hosts)"
       - string:
+          name: BACKUP_STORE_TYPE
+          default: "nfs-and-s3"
+          description: "The valid values for this field are 'nfs', 's3' and 'nfs-and-s3'"
+      - string:
           name: TF_VAR_tf_workspace
           default: /src/longhorn-tests/test_framework
       - bool:

--- a/jenkins-jobs/master/longhorn-tests-rhel-arm64.yml
+++ b/jenkins-jobs/master/longhorn-tests-rhel-arm64.yml
@@ -48,6 +48,10 @@
           default: ""
           description: "pytest custom options to run specific tests (e.g -k test_hosts)"
       - string:
+          name: BACKUP_STORE_TYPE
+          default: "nfs-and-s3"
+          description: "The valid values for this field are 'nfs', 's3' and 'nfs-and-s3'"
+      - string:
           name: TF_VAR_tf_workspace
           default: /src/longhorn-tests/test_framework
       - bool:

--- a/jenkins-jobs/master/longhorn-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/longhorn-tests-sles-amd64.yml
@@ -48,6 +48,10 @@
           default: ""
           description: "pytest custom options to run specific tests (e.g -k test_hosts)"
       - string:
+          name: BACKUP_STORE_TYPE
+          default: "nfs-and-s3"
+          description: "The valid values for this field are 'nfs', 's3' and 'nfs-and-s3'"
+      - string:
           name: TF_VAR_tf_workspace
           default: /src/longhorn-tests/test_framework
       - bool:

--- a/jenkins-jobs/master/longhorn-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/longhorn-tests-sles-arm64.yml
@@ -48,6 +48,10 @@
           default: ""
           description: "pytest custom options to run specific tests (e.g -k test_hosts)"
       - string:
+          name: BACKUP_STORE_TYPE
+          default: "nfs-and-s3"
+          description: "The valid values for this field are 'nfs', 's3' and 'nfs-and-s3'"
+      - string:
           name: TF_VAR_tf_workspace
           default: /src/longhorn-tests/test_framework
       - bool:

--- a/jenkins-jobs/master/longhorn-tests-ubuntu-amd64-nfs-only.yml
+++ b/jenkins-jobs/master/longhorn-tests-ubuntu-amd64-nfs-only.yml
@@ -109,4 +109,4 @@
     triggers:
       - timed: |-
             TZ=America/Los_Angeles
-            H 21 ? * MON,WED,FRI *
+            H 21 * * 1,3,5

--- a/jenkins-jobs/master/longhorn-tests-ubuntu-amd64-s3-only.yml
+++ b/jenkins-jobs/master/longhorn-tests-ubuntu-amd64-s3-only.yml
@@ -109,4 +109,4 @@
     triggers:
       - timed: |-
             TZ=America/Los_Angeles
-            H 21 ? * TUE,THU,SAT *
+            H 21 * * 2,4,6

--- a/jenkins-jobs/master/longhorn-tests-ubuntu-arm64.yml
+++ b/jenkins-jobs/master/longhorn-tests-ubuntu-arm64.yml
@@ -48,6 +48,10 @@
           default: ""
           description: "pytest custom options to run specific tests (e.g -k test_hosts)"
       - string:
+          name: BACKUP_STORE_TYPE
+          default: "nfs-and-s3"
+          description: "The valid values for this field are 'nfs', 's3' and 'nfs-and-s3'"
+      - string:
           name: TF_VAR_tf_workspace
           default: /src/longhorn-tests/test_framework
       - bool:

--- a/jenkins-jobs/master/longhorn-upgrade-tests-rhel-amd64.yml
+++ b/jenkins-jobs/master/longhorn-upgrade-tests-rhel-amd64.yml
@@ -48,6 +48,10 @@
           default: ""
           description: "pytest custom options to run specific tests (e.g -k test_hosts)"
       - string:
+          name: BACKUP_STORE_TYPE
+          default: "nfs-and-s3"
+          description: "The valid values for this field are 'nfs', 's3' and 'nfs-and-s3'"
+      - string:
           name: TF_VAR_tf_workspace
           default: /src/longhorn-tests/test_framework
       - bool:

--- a/jenkins-jobs/master/longhorn-upgrade-tests-rhel-arm64.yml
+++ b/jenkins-jobs/master/longhorn-upgrade-tests-rhel-arm64.yml
@@ -48,6 +48,10 @@
           default: ""
           description: "pytest custom options to run specific tests (e.g -k test_hosts)"
       - string:
+          name: BACKUP_STORE_TYPE
+          default: "nfs-and-s3"
+          description: "The valid values for this field are 'nfs', 's3' and 'nfs-and-s3'"
+      - string:
           name: TF_VAR_tf_workspace
           default: /src/longhorn-tests/test_framework
       - bool:

--- a/jenkins-jobs/master/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/longhorn-upgrade-tests-sles-amd64.yml
@@ -48,6 +48,10 @@
           default: ""
           description: "pytest custom options to run specific tests (e.g -k test_hosts)"
       - string:
+          name: BACKUP_STORE_TYPE
+          default: "nfs-and-s3"
+          description: "The valid values for this field are 'nfs', 's3' and 'nfs-and-s3'"
+      - string:
           name: TF_VAR_tf_workspace
           default: /src/longhorn-tests/test_framework
       - bool:

--- a/jenkins-jobs/master/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/longhorn-upgrade-tests-sles-arm64.yml
@@ -48,6 +48,10 @@
           default: ""
           description: "pytest custom options to run specific tests (e.g -k test_hosts)"
       - string:
+          name: BACKUP_STORE_TYPE
+          default: "nfs-and-s3"
+          description: "The valid values for this field are 'nfs', 's3' and 'nfs-and-s3'"
+      - string:
           name: TF_VAR_tf_workspace
           default: /src/longhorn-tests/test_framework
       - bool:

--- a/jenkins-jobs/master/longhorn-upgrade-tests-ubuntu-amd64.yml
+++ b/jenkins-jobs/master/longhorn-upgrade-tests-ubuntu-amd64.yml
@@ -48,6 +48,10 @@
           default: ""
           description: "pytest custom options to run specific tests (e.g -k test_hosts)"
       - string:
+          name: BACKUP_STORE_TYPE
+          default: "nfs-and-s3"
+          description: "The valid values for this field are 'nfs', 's3' and 'nfs-and-s3'"
+      - string:
           name: TF_VAR_tf_workspace
           default: /src/longhorn-tests/test_framework
       - bool:

--- a/jenkins-jobs/master/longhorn-upgrade-tests-ubuntu-arm64.yml
+++ b/jenkins-jobs/master/longhorn-upgrade-tests-ubuntu-arm64.yml
@@ -48,6 +48,10 @@
           default: ""
           description: "pytest custom options to run specific tests (e.g -k test_hosts)"
       - string:
+          name: BACKUP_STORE_TYPE
+          default: "nfs-and-s3"
+          description: "The valid values for this field are 'nfs', 's3' and 'nfs-and-s3'"
+      - string:
           name: TF_VAR_tf_workspace
           default: /src/longhorn-tests/test_framework
       - bool:

--- a/jenkins-jobs/v1.1.3/longhorn-tests-ubuntu-amd64.yml
+++ b/jenkins-jobs/v1.1.3/longhorn-tests-ubuntu-amd64.yml
@@ -49,6 +49,10 @@
           default: ""
           description: "pytest custom options to run specific tests (e.g -k test_hosts)"
       - string:
+          name: BACKUP_STORE_TYPE
+          default: "nfs-and-s3"
+          description: "The valid values for this field are 'nfs', 's3' and 'nfs-and-s3'"
+      - string:
           name: TF_VAR_tf_workspace
           default: /src/longhorn-tests/test_framework
       - bool:

--- a/jenkins-jobs/v1.1.3/longhorn-tests-ubuntu-arm64.yml
+++ b/jenkins-jobs/v1.1.3/longhorn-tests-ubuntu-arm64.yml
@@ -49,6 +49,10 @@
           default: ""
           description: "pytest custom options to run specific tests (e.g -k test_hosts)"
       - string:
+          name: BACKUP_STORE_TYPE
+          default: "nfs-and-s3"
+          description: "The valid values for this field are 'nfs', 's3' and 'nfs-and-s3'"
+      - string:
           name: TF_VAR_tf_workspace
           default: /src/longhorn-tests/test_framework
       - bool:

--- a/jenkins-jobs/v1.1.3/longhorn-upgrade-tests-ubuntu-amd64.yml
+++ b/jenkins-jobs/v1.1.3/longhorn-upgrade-tests-ubuntu-amd64.yml
@@ -49,6 +49,10 @@
           default: ""
           description: "pytest custom options to run specific tests (e.g -k test_hosts)"
       - string:
+          name: BACKUP_STORE_TYPE
+          default: "nfs-and-s3"
+          description: "The valid values for this field are 'nfs', 's3' and 'nfs-and-s3'"
+      - string:
           name: TF_VAR_tf_workspace
           default: /src/longhorn-tests/test_framework
       - bool:

--- a/jenkins-jobs/v1.1.3/longhorn-upgrade-tests-ubuntu-arm64.yml
+++ b/jenkins-jobs/v1.1.3/longhorn-upgrade-tests-ubuntu-arm64.yml
@@ -49,6 +49,10 @@
           default: ""
           description: "pytest custom options to run specific tests (e.g -k test_hosts)"
       - string:
+          name: BACKUP_STORE_TYPE
+          default: "nfs-and-s3"
+          description: "The valid values for this field are 'nfs', 's3' and 'nfs-and-s3'"
+      - string:
           name: TF_VAR_tf_workspace
           default: /src/longhorn-tests/test_framework
       - bool:

--- a/jenkins-jobs/v1.2.1/longhorn-tests-ubuntu-amd64.yml
+++ b/jenkins-jobs/v1.2.1/longhorn-tests-ubuntu-amd64.yml
@@ -49,6 +49,10 @@
           default: ""
           description: "pytest custom options to run specific tests (e.g -k test_hosts)"
       - string:
+          name: BACKUP_STORE_TYPE
+          default: "nfs-and-s3"
+          description: "The valid values for this field are 'nfs', 's3' and 'nfs-and-s3'"
+      - string:
           name: TF_VAR_tf_workspace
           default: /src/longhorn-tests/test_framework
       - bool:

--- a/jenkins-jobs/v1.2.1/longhorn-tests-ubuntu-arm64.yml
+++ b/jenkins-jobs/v1.2.1/longhorn-tests-ubuntu-arm64.yml
@@ -49,6 +49,10 @@
           default: ""
           description: "pytest custom options to run specific tests (e.g -k test_hosts)"
       - string:
+          name: BACKUP_STORE_TYPE
+          default: "nfs-and-s3"
+          description: "The valid values for this field are 'nfs', 's3' and 'nfs-and-s3'"
+      - string:
           name: TF_VAR_tf_workspace
           default: /src/longhorn-tests/test_framework
       - bool:

--- a/jenkins-jobs/v1.2.1/longhorn-upgrade-tests-ubuntu-amd64.yml
+++ b/jenkins-jobs/v1.2.1/longhorn-upgrade-tests-ubuntu-amd64.yml
@@ -49,6 +49,10 @@
           default: ""
           description: "pytest custom options to run specific tests (e.g -k test_hosts)"
       - string:
+          name: BACKUP_STORE_TYPE
+          default: "nfs-and-s3"
+          description: "The valid values for this field are 'nfs', 's3' and 'nfs-and-s3'"
+      - string:
           name: TF_VAR_tf_workspace
           default: /src/longhorn-tests/test_framework
       - bool:

--- a/jenkins-jobs/v1.2.1/longhorn-upgrade-tests-ubuntu-arm64.yml
+++ b/jenkins-jobs/v1.2.1/longhorn-upgrade-tests-ubuntu-arm64.yml
@@ -49,6 +49,10 @@
           default: ""
           description: "pytest custom options to run specific tests (e.g -k test_hosts)"
       - string:
+          name: BACKUP_STORE_TYPE
+          default: "nfs-and-s3"
+          description: "The valid values for this field are 'nfs', 's3' and 'nfs-and-s3'"
+      - string:
           name: TF_VAR_tf_workspace
           default: /src/longhorn-tests/test_framework
       - bool:


### PR DESCRIPTION
Fix for auto trigger of the jobs nfs and s3 only and addition of variable in all the config files so that they don't fail.

Signed-off-by: Khushboo <fnu.khushboo@suse.com>