### PR TITLE
Cache jenkins job builder

### DIFF
--- a/jenkins-jobs/jenkins-job-builder.yml
+++ b/jenkins-jobs/jenkins-job-builder.yml
@@ -5,7 +5,7 @@
     - shell: |-
         cat <<EOT > jenkins_jobs.ini
         [job_builder]
-        ignore_cache=True
+        ignore_cache=False
         keep_descriptions=False
         include_path=.:scripts:~/git/
         recursive=False
@@ -20,7 +20,7 @@
         query_plugins_info=False
         EOT
 
-        jenkins-jobs --conf ./jenkins_jobs.ini --flush-cache update -r ./jenkins-jobs/
+        jenkins-jobs --conf ./jenkins_jobs.ini update -r ./jenkins-jobs/
         rm -rf jenkins_jobs.ini
     concurrent: false
     disabled: false

--- a/overrides/jenkins-values.yaml
+++ b/overrides/jenkins-values.yaml
@@ -207,3 +207,6 @@ agent:
     - type: HostPath
       hostPath: /var/run/docker.sock
       mountPath: /var/run/docker.sock
+    - type: HostPath
+      hostPath: /home/jenkins/.cache
+      mountPath: /home/jenkins/.cache


### PR DESCRIPTION
Cache jenkins job builder to prevent private folder setting from overwritten.

For https://github.com/longhorn/longhorn/issues/3960

Signed-off-by: Yang Chiu <yang.chiu@suse.com>