### PR TITLE
ci: get rid of longhorn-manger repo in test setup

### DIFF
--- a/jenkins-jobs/longhorn-benchmark-test.yml
+++ b/jenkins-jobs/longhorn-benchmark-test.yml
@@ -17,13 +17,13 @@
           default: true
           description: "send slack notification? (default: true)"
       - string:
-          name: LONGHORN_MANAGER_REPO_URI
-          default: "https://github.com/longhorn/longhorn-manager.git"
-          description: "longhorn-manager repo URI"
+          name: LONGHORN_REPO_URI
+          default: "https://github.com/longhorn/longhorn.git"
+          description: "longhorn repo URI"
       - string:
-          name: LONGHORN_MANAGER_BRANCH
+          name: LONGHORN_REPO_BRANCH
           default: "master"
-          description: "longhorn-manager repo branch"
+          description: "longhorn repo branch"
       - string:
           name: CUSTOM_LONGHORN_MANAGER_IMAGE
           default: "longhornio/longhorn-manager:master-head"

--- a/jenkins-jobs/longhorn-tests-regression.yml
+++ b/jenkins-jobs/longhorn-tests-regression.yml
@@ -90,22 +90,22 @@
           omit-value-field: True
           referenced-parameters: LONGHORN_INSTALL_METHOD
       - dynamic-reference:
-          name: LONGHORN_MANAGER_REPO_URI
-          description: "longhorn-manager repo URI"
+          name: LONGHORN_REPO_URI
+          description: "longhorn repo URI"
           script:
             groovy: |-
               if (!LONGHORN_INSTALL_METHOD.equals('custom')) {
                 return "<input class='setting-input jenkins-input' name='value' value='N/A' type='text' disabled style='opacity: 0.5;'>";
               } else {
-                return "<input class='setting-input jenkins-input' name='value' value='https://github.com/longhorn/longhorn-manager.git' type='text'>";
+                return "<input class='setting-input jenkins-input' name='value' value='https://github.com/longhorn/longhorn.git' type='text'>";
               }
             use-groovy-sandbox: false
           choice-type: formatted-html
           omit-value-field: True
           referenced-parameters: LONGHORN_INSTALL_METHOD
       - dynamic-reference:
-          name: LONGHORN_MANAGER_BRANCH
-          description: "longhorn-manager repo branch"
+          name: LONGHORN_REPO_BRANCH
+          description: "longhorn repo branch"
           script:
             groovy: |-
               if (!LONGHORN_INSTALL_METHOD.equals('custom')) {

--- a/jenkins-jobs/master/centos/longhorn-tests-centos-amd64.yml
+++ b/jenkins-jobs/master/centos/longhorn-tests-centos-amd64.yml
@@ -12,13 +12,13 @@
           default: true
           description: "send slack notification? (default: true)"
       - string:
-          name: LONGHORN_MANAGER_REPO_URI
-          default: "https://github.com/longhorn/longhorn-manager.git"
-          description: "longhorn-manager repo URI"
+          name: LONGHORN_REPO_URI
+          default: "https://github.com/longhorn/longhorn.git"
+          description: "longhorn repo URI"
       - string:
-          name: LONGHORN_MANAGER_BRANCH
+          name: LONGHORN_REPO_BRANCH
           default: "master"
-          description: "longhorn-manager repo branch"
+          description: "longhorn repo branch"
       - string:
           name: CUSTOM_LONGHORN_MANAGER_IMAGE
           default: "longhornio/longhorn-manager:master-head"

--- a/jenkins-jobs/master/centos/longhorn-tests-centos-arm64.yml
+++ b/jenkins-jobs/master/centos/longhorn-tests-centos-arm64.yml
@@ -12,13 +12,13 @@
           default: true
           description: "send slack notification? (default: true)"
       - string:
-          name: LONGHORN_MANAGER_REPO_URI
-          default: "https://github.com/longhorn/longhorn-manager.git"
-          description: "longhorn-manager repo URI"
+          name: LONGHORN_REPO_URI
+          default: "https://github.com/longhorn/longhorn.git"
+          description: "longhorn repo URI"
       - string:
-          name: LONGHORN_MANAGER_BRANCH
+          name: LONGHORN_REPO_BRANCH
           default: "master"
-          description: "longhorn-manager repo branch"
+          description: "longhorn repo branch"
       - string:
           name: CUSTOM_LONGHORN_MANAGER_IMAGE
           default: "longhornio/longhorn-manager:master-head"

--- a/jenkins-jobs/master/centos/longhorn-upgrade-tests-centos-amd64.yml
+++ b/jenkins-jobs/master/centos/longhorn-upgrade-tests-centos-amd64.yml
@@ -12,13 +12,13 @@
           default: true
           description: "send slack notification? (default: true)"
       - string:
-          name: LONGHORN_MANAGER_REPO_URI
-          default: "https://github.com/longhorn/longhorn-manager.git"
-          description: "longhorn-manager repo URI"
+          name: LONGHORN_REPO_URI
+          default: "https://github.com/longhorn/longhorn.git"
+          description: "longhorn repo URI"
       - string:
-          name: LONGHORN_MANAGER_BRANCH
+          name: LONGHORN_REPO_BRANCH
           default: "master"
-          description: "longhorn-manager repo branch"
+          description: "longhorn repo branch"
       - string:
           name: CUSTOM_LONGHORN_MANAGER_IMAGE
           default: "longhornio/longhorn-manager:master-head"

--- a/jenkins-jobs/master/centos/longhorn-upgrade-tests-centos-arm64.yml
+++ b/jenkins-jobs/master/centos/longhorn-upgrade-tests-centos-arm64.yml
@@ -12,13 +12,13 @@
           default: true
           description: "send slack notification? (default: true)"
       - string:
-          name: LONGHORN_MANAGER_REPO_URI
-          default: "https://github.com/longhorn/longhorn-manager.git"
-          description: "longhorn-manager repo URI"
+          name: LONGHORN_REPO_URI
+          default: "https://github.com/longhorn/longhorn.git"
+          description: "longhorn repo URI"
       - string:
-          name: LONGHORN_MANAGER_BRANCH
+          name: LONGHORN_REPO_BRANCH
           default: "master"
-          description: "longhorn-manager repo branch"
+          description: "longhorn repo branch"
       - string:
           name: CUSTOM_LONGHORN_MANAGER_IMAGE
           default: "longhornio/longhorn-manager:master-head"

--- a/jenkins-jobs/master/oracle/longhorn-tests-oracle-amd64.yml
+++ b/jenkins-jobs/master/oracle/longhorn-tests-oracle-amd64.yml
@@ -12,13 +12,13 @@
           default: true
           description: "send slack notification? (default: true)"
       - string:
-          name: LONGHORN_MANAGER_REPO_URI
-          default: "https://github.com/longhorn/longhorn-manager.git"
-          description: "longhorn-manager repo URI"
+          name: LONGHORN_REPO_URI
+          default: "https://github.com/longhorn/longhorn.git"
+          description: "longhorn repo URI"
       - string:
-          name: LONGHORN_MANAGER_BRANCH
+          name: LONGHORN_REPO_BRANCH
           default: "master"
-          description: "longhorn-manager repo branch"
+          description: "longhorn repo branch"
       - string:
           name: CUSTOM_LONGHORN_MANAGER_IMAGE
           default: "longhornio/longhorn-manager:master-head"

--- a/jenkins-jobs/master/oracle/longhorn-upgrade-tests-oracle-amd64.yml
+++ b/jenkins-jobs/master/oracle/longhorn-upgrade-tests-oracle-amd64.yml
@@ -12,13 +12,13 @@
           default: true
           description: "send slack notification? (default: true)"
       - string:
-          name: LONGHORN_MANAGER_REPO_URI
-          default: "https://github.com/longhorn/longhorn-manager.git"
-          description: "longhorn-manager repo URI"
+          name: LONGHORN_REPO_URI
+          default: "https://github.com/longhorn/longhorn.git"
+          description: "longhorn repo URI"
       - string:
-          name: LONGHORN_MANAGER_BRANCH
+          name: LONGHORN_REPO_BRANCH
           default: "master"
-          description: "longhorn-manager repo branch"
+          description: "longhorn repo branch"
       - string:
           name: CUSTOM_LONGHORN_MANAGER_IMAGE
           default: "longhornio/longhorn-manager:master-head"

--- a/jenkins-jobs/master/rhel/longhorn-tests-rhel-amd64.yml
+++ b/jenkins-jobs/master/rhel/longhorn-tests-rhel-amd64.yml
@@ -12,13 +12,13 @@
           default: true
           description: "send slack notification? (default: true)"
       - string:
-          name: LONGHORN_MANAGER_REPO_URI
-          default: "https://github.com/longhorn/longhorn-manager.git"
-          description: "longhorn-manager repo URI"
+          name: LONGHORN_REPO_URI
+          default: "https://github.com/longhorn/longhorn.git"
+          description: "longhorn repo URI"
       - string:
-          name: LONGHORN_MANAGER_BRANCH
+          name: LONGHORN_REPO_BRANCH
           default: "master"
-          description: "longhorn-manager repo branch"
+          description: "longhorn repo branch"
       - string:
           name: CUSTOM_LONGHORN_MANAGER_IMAGE
           default: "longhornio/longhorn-manager:master-head"

--- a/jenkins-jobs/master/rhel/longhorn-tests-rhel-arm64.yml
+++ b/jenkins-jobs/master/rhel/longhorn-tests-rhel-arm64.yml
@@ -12,13 +12,13 @@
           default: true
           description: "send slack notification? (default: true)"
       - string:
-          name: LONGHORN_MANAGER_REPO_URI
-          default: "https://github.com/longhorn/longhorn-manager.git"
-          description: "longhorn-manager repo URI"
+          name: LONGHORN_REPO_URI
+          default: "https://github.com/longhorn/longhorn.git"
+          description: "longhorn repo URI"
       - string:
-          name: LONGHORN_MANAGER_BRANCH
+          name: LONGHORN_REPO_BRANCH
           default: "master"
-          description: "longhorn-manager repo branch"
+          description: "longhorn repo branch"
       - string:
           name: CUSTOM_LONGHORN_MANAGER_IMAGE
           default: "longhornio/longhorn-manager:master-head"

--- a/jenkins-jobs/master/rhel/longhorn-upgrade-tests-rhel-amd64.yml
+++ b/jenkins-jobs/master/rhel/longhorn-upgrade-tests-rhel-amd64.yml
@@ -12,13 +12,13 @@
           default: true
           description: "send slack notification? (default: true)"
       - string:
-          name: LONGHORN_MANAGER_REPO_URI
-          default: "https://github.com/longhorn/longhorn-manager.git"
-          description: "longhorn-manager repo URI"
+          name: LONGHORN_REPO_URI
+          default: "https://github.com/longhorn/longhorn.git"
+          description: "longhorn repo URI"
       - string:
-          name: LONGHORN_MANAGER_BRANCH
+          name: LONGHORN_REPO_BRANCH
           default: "master"
-          description: "longhorn-manager repo branch"
+          description: "longhorn repo branch"
       - string:
           name: CUSTOM_LONGHORN_MANAGER_IMAGE
           default: "longhornio/longhorn-manager:master-head"

--- a/jenkins-jobs/master/rhel/longhorn-upgrade-tests-rhel-arm64.yml
+++ b/jenkins-jobs/master/rhel/longhorn-upgrade-tests-rhel-arm64.yml
@@ -12,13 +12,13 @@
           default: true
           description: "send slack notification? (default: true)"
       - string:
-          name: LONGHORN_MANAGER_REPO_URI
-          default: "https://github.com/longhorn/longhorn-manager.git"
-          description: "longhorn-manager repo URI"
+          name: LONGHORN_REPO_URI
+          default: "https://github.com/longhorn/longhorn.git"
+          description: "longhorn repo URI"
       - string:
-          name: LONGHORN_MANAGER_BRANCH
+          name: LONGHORN_REPO_BRANCH
           default: "master"
-          description: "longhorn-manager repo branch"
+          description: "longhorn repo branch"
       - string:
           name: CUSTOM_LONGHORN_MANAGER_IMAGE
           default: "longhornio/longhorn-manager:master-head"

--- a/jenkins-jobs/master/rockylinux/longhorn-tests-rockylinux-amd64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-tests-rockylinux-amd64.yml
@@ -12,13 +12,13 @@
           default: true
           description: "send slack notification? (default: true)"
       - string:
-          name: LONGHORN_MANAGER_REPO_URI
-          default: "https://github.com/longhorn/longhorn-manager.git"
-          description: "longhorn-manager repo URI"
+          name: LONGHORN_REPO_URI
+          default: "https://github.com/longhorn/longhorn.git"
+          description: "longhorn repo URI"
       - string:
-          name: LONGHORN_MANAGER_BRANCH
+          name: LONGHORN_REPO_BRANCH
           default: "master"
-          description: "longhorn-manager repo branch"
+          description: "longhorn repo branch"
       - string:
           name: CUSTOM_LONGHORN_MANAGER_IMAGE
           default: "longhornio/longhorn-manager:master-head"

--- a/jenkins-jobs/master/rockylinux/longhorn-tests-rockylinux-arm64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-tests-rockylinux-arm64.yml
@@ -12,13 +12,13 @@
           default: true
           description: "send slack notification? (default: true)"
       - string:
-          name: LONGHORN_MANAGER_REPO_URI
-          default: "https://github.com/longhorn/longhorn-manager.git"
-          description: "longhorn-manager repo URI"
+          name: LONGHORN_REPO_URI
+          default: "https://github.com/longhorn/longhorn.git"
+          description: "longhorn repo URI"
       - string:
-          name: LONGHORN_MANAGER_BRANCH
+          name: LONGHORN_REPO_BRANCH
           default: "master"
-          description: "longhorn-manager repo branch"
+          description: "longhorn repo branch"
       - string:
           name: CUSTOM_LONGHORN_MANAGER_IMAGE
           default: "longhornio/longhorn-manager:master-head"

--- a/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-amd64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-amd64.yml
@@ -12,13 +12,13 @@
           default: true
           description: "send slack notification? (default: true)"
       - string:
-          name: LONGHORN_MANAGER_REPO_URI
-          default: "https://github.com/longhorn/longhorn-manager.git"
-          description: "longhorn-manager repo URI"
+          name: LONGHORN_REPO_URI
+          default: "https://github.com/longhorn/longhorn.git"
+          description: "longhorn repo URI"
       - string:
-          name: LONGHORN_MANAGER_BRANCH
+          name: LONGHORN_REPO_BRANCH
           default: "master"
-          description: "longhorn-manager repo branch"
+          description: "longhorn repo branch"
       - string:
           name: CUSTOM_LONGHORN_MANAGER_IMAGE
           default: "longhornio/longhorn-manager:master-head"

--- a/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-arm64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-arm64.yml
@@ -12,13 +12,13 @@
           default: true
           description: "send slack notification? (default: true)"
       - string:
-          name: LONGHORN_MANAGER_REPO_URI
-          default: "https://github.com/longhorn/longhorn-manager.git"
-          description: "longhorn-manager repo URI"
+          name: LONGHORN_REPO_URI
+          default: "https://github.com/longhorn/longhorn.git"
+          description: "longhorn repo URI"
       - string:
-          name: LONGHORN_MANAGER_BRANCH
+          name: LONGHORN_REPO_BRANCH
           default: "master"
-          description: "longhorn-manager repo branch"
+          description: "longhorn repo branch"
       - string:
           name: CUSTOM_LONGHORN_MANAGER_IMAGE
           default: "longhornio/longhorn-manager:master-head"

--- a/jenkins-jobs/master/sles/longhorn-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/sles/longhorn-tests-sles-amd64.yml
@@ -12,13 +12,13 @@
           default: true
           description: "send slack notification? (default: true)"
       - string:
-          name: LONGHORN_MANAGER_REPO_URI
-          default: "https://github.com/longhorn/longhorn-manager.git"
-          description: "longhorn-manager repo URI"
+          name: LONGHORN_REPO_URI
+          default: "https://github.com/longhorn/longhorn.git"
+          description: "longhorn repo URI"
       - string:
-          name: LONGHORN_MANAGER_BRANCH
+          name: LONGHORN_REPO_BRANCH
           default: "master"
-          description: "longhorn-manager repo branch"
+          description: "longhorn repo branch"
       - string:
           name: CUSTOM_LONGHORN_MANAGER_IMAGE
           default: "longhornio/longhorn-manager:master-head"

--- a/jenkins-jobs/master/sles/longhorn-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/sles/longhorn-tests-sles-arm64.yml
@@ -12,13 +12,13 @@
           default: true
           description: "send slack notification? (default: true)"
       - string:
-          name: LONGHORN_MANAGER_REPO_URI
-          default: "https://github.com/longhorn/longhorn-manager.git"
-          description: "longhorn-manager repo URI"
+          name: LONGHORN_REPO_URI
+          default: "https://github.com/longhorn/longhorn.git"
+          description: "longhorn repo URI"
       - string:
-          name: LONGHORN_MANAGER_BRANCH
+          name: LONGHORN_REPO_BRANCH
           default: "master"
-          description: "longhorn-manager repo branch"
+          description: "longhorn repo branch"
       - string:
           name: CUSTOM_LONGHORN_MANAGER_IMAGE
           default: "longhornio/longhorn-manager:master-head"

--- a/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-amd64.yml
@@ -12,13 +12,13 @@
           default: true
           description: "send slack notification? (default: true)"
       - string:
-          name: LONGHORN_MANAGER_REPO_URI
-          default: "https://github.com/longhorn/longhorn-manager.git"
-          description: "longhorn-manager repo URI"
+          name: LONGHORN_REPO_URI
+          default: "https://github.com/longhorn/longhorn.git"
+          description: "longhorn repo URI"
       - string:
-          name: LONGHORN_MANAGER_BRANCH
+          name: LONGHORN_REPO_BRANCH
           default: "master"
-          description: "longhorn-manager repo branch"
+          description: "longhorn repo branch"
       - string:
           name: CUSTOM_LONGHORN_MANAGER_IMAGE
           default: "longhornio/longhorn-manager:master-head"

--- a/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-arm64.yml
@@ -12,13 +12,13 @@
           default: true
           description: "send slack notification? (default: true)"
       - string:
-          name: LONGHORN_MANAGER_REPO_URI
-          default: "https://github.com/longhorn/longhorn-manager.git"
-          description: "longhorn-manager repo URI"
+          name: LONGHORN_REPO_URI
+          default: "https://github.com/longhorn/longhorn.git"
+          description: "longhorn repo URI"
       - string:
-          name: LONGHORN_MANAGER_BRANCH
+          name: LONGHORN_REPO_BRANCH
           default: "master"
-          description: "longhorn-manager repo branch"
+          description: "longhorn repo branch"
       - string:
           name: CUSTOM_LONGHORN_MANAGER_IMAGE
           default: "longhornio/longhorn-manager:master-head"

--- a/jenkins-jobs/master/ubuntu/longhorn-tests-ubuntu-amd64.yml
+++ b/jenkins-jobs/master/ubuntu/longhorn-tests-ubuntu-amd64.yml
@@ -12,13 +12,13 @@
           default: true
           description: "send slack notification? (default: true)"
       - string:
-          name: LONGHORN_MANAGER_REPO_URI
-          default: "https://github.com/longhorn/longhorn-manager.git"
-          description: "longhorn-manager repo URI"
+          name: LONGHORN_REPO_URI
+          default: "https://github.com/longhorn/longhorn.git"
+          description: "longhorn repo URI"
       - string:
-          name: LONGHORN_MANAGER_BRANCH
+          name: LONGHORN_REPO_BRANCH
           default: "master"
-          description: "longhorn-manager repo branch"
+          description: "longhorn repo branch"
       - string:
           name: CUSTOM_LONGHORN_MANAGER_IMAGE
           default: "longhornio/longhorn-manager:master-head"

--- a/jenkins-jobs/master/ubuntu/longhorn-tests-ubuntu-arm64.yml
+++ b/jenkins-jobs/master/ubuntu/longhorn-tests-ubuntu-arm64.yml
@@ -12,13 +12,13 @@
           default: true
           description: "send slack notification? (default: true)"
       - string:
-          name: LONGHORN_MANAGER_REPO_URI
-          default: "https://github.com/longhorn/longhorn-manager.git"
-          description: "longhorn-manager repo URI"
+          name: LONGHORN_REPO_URI
+          default: "https://github.com/longhorn/longhorn.git"
+          description: "longhorn repo URI"
       - string:
-          name: LONGHORN_MANAGER_BRANCH
+          name: LONGHORN_REPO_BRANCH
           default: "master"
-          description: "longhorn-manager repo branch"
+          description: "longhorn repo branch"
       - string:
           name: CUSTOM_LONGHORN_MANAGER_IMAGE
           default: "longhornio/longhorn-manager:master-head"

--- a/jenkins-jobs/master/ubuntu/longhorn-upgrade-tests-ubuntu-amd64.yml
+++ b/jenkins-jobs/master/ubuntu/longhorn-upgrade-tests-ubuntu-amd64.yml
@@ -12,13 +12,13 @@
           default: true
           description: "send slack notification? (default: true)"
       - string:
-          name: LONGHORN_MANAGER_REPO_URI
-          default: "https://github.com/longhorn/longhorn-manager.git"
-          description: "longhorn-manager repo URI"
+          name: LONGHORN_REPO_URI
+          default: "https://github.com/longhorn/longhorn.git"
+          description: "longhorn repo URI"
       - string:
-          name: LONGHORN_MANAGER_BRANCH
+          name: LONGHORN_REPO_BRANCH
           default: "master"
-          description: "longhorn-manager repo branch"
+          description: "longhorn repo branch"
       - string:
           name: CUSTOM_LONGHORN_MANAGER_IMAGE
           default: "longhornio/longhorn-manager:master-head"

--- a/jenkins-jobs/master/ubuntu/longhorn-upgrade-tests-ubuntu-arm64.yml
+++ b/jenkins-jobs/master/ubuntu/longhorn-upgrade-tests-ubuntu-arm64.yml
@@ -12,13 +12,13 @@
           default: true
           description: "send slack notification? (default: true)"
       - string:
-          name: LONGHORN_MANAGER_REPO_URI
-          default: "https://github.com/longhorn/longhorn-manager.git"
-          description: "longhorn-manager repo URI"
+          name: LONGHORN_REPO_URI
+          default: "https://github.com/longhorn/longhorn.git"
+          description: "longhorn repo URI"
       - string:
-          name: LONGHORN_MANAGER_BRANCH
+          name: LONGHORN_REPO_BRANCH
           default: "master"
-          description: "longhorn-manager repo branch"
+          description: "longhorn repo branch"
       - string:
           name: CUSTOM_LONGHORN_MANAGER_IMAGE
           default: "longhornio/longhorn-manager:master-head"

--- a/jenkins-jobs/v1.2.x/longhorn-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.2.x/longhorn-tests-sles-amd64.yml
@@ -12,13 +12,13 @@
           default: true
           description: "send slack notification? (default: true)"
       - string:
-          name: LONGHORN_MANAGER_REPO_URI
-          default: "https://github.com/longhorn/longhorn-manager.git"
-          description: "longhorn-manager repo URI"
+          name: LONGHORN_REPO_URI
+          default: "https://github.com/longhorn/longhorn.git"
+          description: "longhorn repo URI"
       - string:
-          name: LONGHORN_MANAGER_BRANCH
+          name: LONGHORN_REPO_BRANCH
           default: "v1.2.x"
-          description: "longhorn-manager repo branch"
+          description: "longhorn repo branch"
       - string:
           name: CUSTOM_LONGHORN_MANAGER_IMAGE
           default: "longhornio/longhorn-manager:v1.2.x-head"

--- a/jenkins-jobs/v1.2.x/longhorn-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.2.x/longhorn-tests-sles-arm64.yml
@@ -12,13 +12,13 @@
           default: true
           description: "send slack notification? (default: true)"
       - string:
-          name: LONGHORN_MANAGER_REPO_URI
-          default: "https://github.com/longhorn/longhorn-manager.git"
-          description: "longhorn-manager repo URI"
+          name: LONGHORN_REPO_URI
+          default: "https://github.com/longhorn/longhorn.git"
+          description: "longhorn repo URI"
       - string:
-          name: LONGHORN_MANAGER_BRANCH
+          name: LONGHORN_REPO_BRANCH
           default: "v1.2.x"
-          description: "longhorn-manager repo branch"
+          description: "longhorn repo branch"
       - string:
           name: CUSTOM_LONGHORN_MANAGER_IMAGE
           default: "longhornio/longhorn-manager:v1.2.x-head"

--- a/jenkins-jobs/v1.2.x/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.2.x/longhorn-upgrade-tests-sles-amd64.yml
@@ -12,13 +12,13 @@
           default: true
           description: "send slack notification? (default: true)"
       - string:
-          name: LONGHORN_MANAGER_REPO_URI
-          default: "https://github.com/longhorn/longhorn-manager.git"
-          description: "longhorn-manager repo URI"
+          name: LONGHORN_REPO_URI
+          default: "https://github.com/longhorn/longhorn.git"
+          description: "longhorn repo URI"
       - string:
-          name: LONGHORN_MANAGER_BRANCH
+          name: LONGHORN_REPO_BRANCH
           default: "v1.2.x"
-          description: "longhorn-manager repo branch"
+          description: "longhorn repo branch"
       - string:
           name: CUSTOM_LONGHORN_MANAGER_IMAGE
           default: "longhornio/longhorn-manager:v1.2.x-head"

--- a/jenkins-jobs/v1.2.x/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.2.x/longhorn-upgrade-tests-sles-arm64.yml
@@ -12,13 +12,13 @@
           default: true
           description: "send slack notification? (default: true)"
       - string:
-          name: LONGHORN_MANAGER_REPO_URI
-          default: "https://github.com/longhorn/longhorn-manager.git"
-          description: "longhorn-manager repo URI"
+          name: LONGHORN_REPO_URI
+          default: "https://github.com/longhorn/longhorn.git"
+          description: "longhorn repo URI"
       - string:
-          name: LONGHORN_MANAGER_BRANCH
+          name: LONGHORN_REPO_BRANCH
           default: "v1.2.x"
-          description: "longhorn-manager repo branch"
+          description: "longhorn repo branch"
       - string:
           name: CUSTOM_LONGHORN_MANAGER_IMAGE
           default: "longhornio/longhorn-manager:v1.2.x-head"

--- a/jenkins-jobs/v1.3.x/longhorn-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.3.x/longhorn-tests-sles-amd64.yml
@@ -12,13 +12,13 @@
           default: true
           description: "send slack notification? (default: true)"
       - string:
-          name: LONGHORN_MANAGER_REPO_URI
-          default: "https://github.com/longhorn/longhorn-manager.git"
-          description: "longhorn-manager repo URI"
+          name: LONGHORN_REPO_URI
+          default: "https://github.com/longhorn/longhorn.git"
+          description: "longhorn repo URI"
       - string:
-          name: LONGHORN_MANAGER_BRANCH
+          name: LONGHORN_REPO_BRANCH
           default: "v1.3.x"
-          description: "longhorn-manager repo branch"
+          description: "longhorn repo branch"
       - string:
           name: CUSTOM_LONGHORN_MANAGER_IMAGE
           default: "longhornio/longhorn-manager:v1.3.x-head"

--- a/jenkins-jobs/v1.3.x/longhorn-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.3.x/longhorn-tests-sles-arm64.yml
@@ -12,13 +12,13 @@
           default: true
           description: "send slack notification? (default: true)"
       - string:
-          name: LONGHORN_MANAGER_REPO_URI
-          default: "https://github.com/longhorn/longhorn-manager.git"
-          description: "longhorn-manager repo URI"
+          name: LONGHORN_REPO_URI
+          default: "https://github.com/longhorn/longhorn.git"
+          description: "longhorn repo URI"
       - string:
-          name: LONGHORN_MANAGER_BRANCH
+          name: LONGHORN_REPO_BRANCH
           default: "v1.3.x"
-          description: "longhorn-manager repo branch"
+          description: "longhorn repo branch"
       - string:
           name: CUSTOM_LONGHORN_MANAGER_IMAGE
           default: "longhornio/longhorn-manager:v1.3.x-head"

--- a/jenkins-jobs/v1.3.x/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.3.x/longhorn-upgrade-tests-sles-amd64.yml
@@ -12,13 +12,13 @@
           default: true
           description: "send slack notification? (default: true)"
       - string:
-          name: LONGHORN_MANAGER_REPO_URI
-          default: "https://github.com/longhorn/longhorn-manager.git"
-          description: "longhorn-manager repo URI"
+          name: LONGHORN_REPO_URI
+          default: "https://github.com/longhorn/longhorn.git"
+          description: "longhorn repo URI"
       - string:
-          name: LONGHORN_MANAGER_BRANCH
+          name: LONGHORN_REPO_BRANCH
           default: "v1.3.x"
-          description: "longhorn-manager repo branch"
+          description: "longhorn repo branch"
       - string:
           name: CUSTOM_LONGHORN_MANAGER_IMAGE
           default: "longhornio/longhorn-manager:v1.3.x-head"

--- a/jenkins-jobs/v1.3.x/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.3.x/longhorn-upgrade-tests-sles-arm64.yml
@@ -12,13 +12,13 @@
           default: true
           description: "send slack notification? (default: true)"
       - string:
-          name: LONGHORN_MANAGER_REPO_URI
-          default: "https://github.com/longhorn/longhorn-manager.git"
-          description: "longhorn-manager repo URI"
+          name: LONGHORN_REPO_URI
+          default: "https://github.com/longhorn/longhorn.git"
+          description: "longhorn repo URI"
       - string:
-          name: LONGHORN_MANAGER_BRANCH
+          name: LONGHORN_REPO_BRANCH
           default: "v1.3.x"
-          description: "longhorn-manager repo branch"
+          description: "longhorn repo branch"
       - string:
           name: CUSTOM_LONGHORN_MANAGER_IMAGE
           default: "longhornio/longhorn-manager:v1.3.x-head"


### PR DESCRIPTION
ci: get rid of longhorn-manger repo in test setup

For https://github.com/longhorn/longhorn/issues/4476

Signed-off-by: Yang Chiu <yang.chiu@suse.com>