### PR TITLE
Add param COMMIT_ID in build-engine-test-images pipeline

### DIFF
--- a/jenkins-jobs/build-engine-test-images.yml
+++ b/jenkins-jobs/build-engine-test-images.yml
@@ -11,7 +11,12 @@
       - string:
           name: DOCKER_REPO
           default: "longhornio/longhorn-test"
-          description: "Docker repo for engine test images"
+          description: "Docker repo for push engine test images"
+      - string:
+          name: COMMIT_ID
+          default: ""
+          description: "Build test engine image by git clone https://github.com/longhorn/longhorn-engine.git --branch ${commit_id} --single-branch \n
+                        Empty value will means pull master-head to build test images\n"                       
     pipeline-scm:
       scm:
         - git:
@@ -20,3 +25,4 @@
               - master
       script-path: build_engine_test_images/Jenkinsfile
       lightweight-checkout: true
+


### PR DESCRIPTION
Signed-off-by: Chris Chien <chris.chien@suse.com>

https://github.com/longhorn/longhorn/issues/4615
Add param `COMMIT_ID` in build-engine-test-images pipeline
In case we need to build old API version engine upgrade test images


Longhorn v1.2.x engine upgrade test [result](https://ci.longhorn.io/job/private/job/longhorn-tests-regression/2067/) with [upgrade-test.5-3.3-3.1-1](https://hub.docker.com/layers/chanow/longhorn-manager-test/upgrade-test.5-3.3-3.1-1/images/sha256-14237c8bac6c32fc44552e37b76199b1e7b6683052e42c4f879e8b6ac5f1bf84?context=repo) 
Longhorn master-head engine upgrade test [result](https://ci.longhorn.io/job/private/job/longhorn-tests-regression/2068/) with [upgrade-test.6-3.3-3.1-1](https://hub.docker.com/layers/chanow/longhorn-test/upgrade-test.6-3.3-3.1-1/images/sha256-1d160111b798c0b06e29d91c327d15a0caa2f6ac06ed847ec5dd81a7880e5140?context=repo) 
