### PR TITLE
ci: set sles default version to 15-sp4 and update rocky/rhel/oracle version info

### DIFF
--- a/jenkins-jobs/longhorn-benchmark-test.yml
+++ b/jenkins-jobs/longhorn-benchmark-test.yml
@@ -85,10 +85,15 @@
           description: "Linux distro used to install on created instances, supported values: [sles]"
       - string:
           name: DISTRO_VERSION
-          default: "15-sp3-v20210622"
+          default: "15-sp4-v20220621"
           description: |
-              Linux distro version to install on created instances, choosed based on DISTRO values
-              for DISTRO=sles, supported values: [15-sp3-v20210622], default: [15-sp3-v20210622]
+             Linux distro version to install on created instances, choosed based on DISTRO values
+             for DISTRO=ubuntu, supported values: [18.04, 20.04, 22.04], default: [20.04]
+             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220621], default: [15-sp4-v20220621]
+             for DISTRO=rockylinux, supported values: [8.5, 8.6], default: [8.6]
+             for DISTRO=rhel, supported values: [8.4.0, 8.6.0], default: [8.6.0]
+             for DISTRO=oracle, supported values: [8.5, 8.6], default: [8.6]
+             for DISTRO=centos, supported values: [8.4], default: [8.4]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
           default: "c5d.2xlarge"

--- a/jenkins-jobs/longhorn-tests-regression.yml
+++ b/jenkins-jobs/longhorn-tests-regression.yml
@@ -254,14 +254,14 @@
           description: "Linux distro used to install on created instances, supported values: [ubuntu, rhel, sles, centos, oracle, rockylinux]"
       - string:
           name: DISTRO_VERSION
-          default: "15-sp3-v20210622"
+          default: "15-sp4-v20220621"
           description: |
              Linux distro version to install on created instances, choosed based on DISTRO values
              for DISTRO=ubuntu, supported values: [18.04, 20.04, 22.04], default: [20.04]
-             for DISTRO=sles, supported values: [15-sp3-v20210622], default: [15-sp3-v20210622]
-             for DISTRO=rockylinux, supported values: [8.5], default: [8.5]
-             for DISTRO=rhel, supported values: [7.9 ,8.3, 8.4.0], default: [8.3]
-             for DISTRO=oracle, supported values: [8.3, 8.5], default: [8.5]
+             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220621], default: [15-sp4-v20220621]
+             for DISTRO=rockylinux, supported values: [8.5, 8.6], default: [8.6]
+             for DISTRO=rhel, supported values: [8.4.0, 8.6.0], default: [8.6.0]
+             for DISTRO=oracle, supported values: [8.5, 8.6], default: [8.6]
              for DISTRO=centos, supported values: [8.4], default: [8.4]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE

--- a/jenkins-jobs/master/sles/longhorn-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/sles/longhorn-tests-sles-amd64.yml
@@ -95,15 +95,15 @@
           description: "Linux distro used to install on created instances, supported values: [ubuntu, rhel, sles, centos, oracle, rockylinux]"
       - string:
           name: DISTRO_VERSION
-          default: "15-sp3-v20210622"
+          default: "15-sp4-v20220621"
           description: |
              Linux distro version to install on created instances, choosed based on DISTRO values
-             for DISTRO=ubuntu, supported values: [18.04, 20.04], default: [20.04]
-             for DISTRO=rhel, supported values: [7.9 ,8.3, 8.4.0], default: [8.3]
-             for DISTRO=sles, supported values: [15-sp3-v20210622], default: [15-sp3-v20210622]
+             for DISTRO=ubuntu, supported values: [18.04, 20.04, 22.04], default: [20.04]
+             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220621], default: [15-sp4-v20220621]
+             for DISTRO=rockylinux, supported values: [8.5, 8.6], default: [8.6]
+             for DISTRO=rhel, supported values: [8.4.0, 8.6.0], default: [8.6.0]
+             for DISTRO=oracle, supported values: [8.5, 8.6], default: [8.6]
              for DISTRO=centos, supported values: [8.4], default: [8.4]
-             for DISTRO=oracle, supported values: [8.3], default: [8.3]
-             for DISTRO=rockylinux, supported values: [8.4], default: [8.4]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
           default: "t2.xlarge"

--- a/jenkins-jobs/master/sles/longhorn-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/sles/longhorn-tests-sles-arm64.yml
@@ -95,15 +95,15 @@
           description: "Linux distro used to install on created instances, supported values: [ubuntu, rhel, sles, centos, oracle, rockylinux]"
       - string:
           name: DISTRO_VERSION
-          default: "15-sp3-v20210622"
+          default: "15-sp4-v20220621"
           description: |
              Linux distro version to install on created instances, choosed based on DISTRO values
-             for DISTRO=ubuntu, supported values: [18.04, 20.04], default: [20.04]
-             for DISTRO=rhel, supported values: [7.9 ,8.3, 8.4.0], default: [8.3]
-             for DISTRO=sles, supported values: [15-sp3-v20210622], default: [15-sp3-v20210622]
+             for DISTRO=ubuntu, supported values: [18.04, 20.04, 22.04], default: [20.04]
+             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220621], default: [15-sp4-v20220621]
+             for DISTRO=rockylinux, supported values: [8.5, 8.6], default: [8.6]
+             for DISTRO=rhel, supported values: [8.4.0, 8.6.0], default: [8.6.0]
+             for DISTRO=oracle, supported values: [8.5, 8.6], default: [8.6]
              for DISTRO=centos, supported values: [8.4], default: [8.4]
-             for DISTRO=oracle, supported values: [8.3], default: [8.3]
-             for DISTRO=rockylinux, supported values: [8.4], default: [8.4]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
           default: "a1.xlarge"

--- a/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-amd64.yml
@@ -95,15 +95,15 @@
           description: "Linux distro used to install on created instances, supported values: [ubuntu, rhel, sles, centos, oracle, rockylinux]"
       - string:
           name: DISTRO_VERSION
-          default: "15-sp3-v20210622"
+          default: "15-sp4-v20220621"
           description: |
              Linux distro version to install on created instances, choosed based on DISTRO values
-             for DISTRO=ubuntu, supported values: [18.04, 20.04], default: [20.04]
-             for DISTRO=rhel, supported values: [7.9 ,8.3, 8.4.0], default: [8.3]
-             for DISTRO=sles, supported values: [15-sp3-v20210622], default: [15-sp3-v20210622]
+             for DISTRO=ubuntu, supported values: [18.04, 20.04, 22.04], default: [20.04]
+             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220621], default: [15-sp4-v20220621]
+             for DISTRO=rockylinux, supported values: [8.5, 8.6], default: [8.6]
+             for DISTRO=rhel, supported values: [8.4.0, 8.6.0], default: [8.6.0]
+             for DISTRO=oracle, supported values: [8.5, 8.6], default: [8.6]
              for DISTRO=centos, supported values: [8.4], default: [8.4]
-             for DISTRO=oracle, supported values: [8.3], default: [8.3]
-             for DISTRO=rockylinux, supported values: [8.4], default: [8.4]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
           default: "t2.xlarge"

--- a/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-arm64.yml
@@ -95,15 +95,15 @@
           description: "Linux distro used to install on created instances, supported values: [ubuntu, rhel, sles, centos, oracle, rockylinux]"
       - string:
           name: DISTRO_VERSION
-          default: "15-sp3-v20210622"
+          default: "15-sp4-v20220621"
           description: |
              Linux distro version to install on created instances, choosed based on DISTRO values
-             for DISTRO=ubuntu, supported values: [18.04, 20.04], default: [20.04]
-             for DISTRO=rhel, supported values: [7.9 ,8.3, 8.4.0], default: [8.3]
-             for DISTRO=sles, supported values: [15-sp3-v20210622], default: [15-sp3-v20210622]
+             for DISTRO=ubuntu, supported values: [18.04, 20.04, 22.04], default: [20.04]
+             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220621], default: [15-sp4-v20220621]
+             for DISTRO=rockylinux, supported values: [8.5, 8.6], default: [8.6]
+             for DISTRO=rhel, supported values: [8.4.0, 8.6.0], default: [8.6.0]
+             for DISTRO=oracle, supported values: [8.5, 8.6], default: [8.6]
              for DISTRO=centos, supported values: [8.4], default: [8.4]
-             for DISTRO=oracle, supported values: [8.3], default: [8.3]
-             for DISTRO=rockylinux, supported values: [8.4], default: [8.4]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
           default: "a1.xlarge"


### PR DESCRIPTION
ci: set sles default version to 15-sp4 and update rocky/rhel/oracle version info

For https://github.com/longhorn/longhorn/issues/4620, https://github.com/longhorn/longhorn/issues/4618

Signed-off-by: Yang Chiu <yang.chiu@suse.com>