### PR TITLE
ci: update default k8s version to v1.25 on master branch

### DIFF
--- a/jenkins-jobs/master/sles/longhorn-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/sles/longhorn-tests-sles-amd64.yml
@@ -84,11 +84,12 @@
           description: "kubernetes distro version to install [rke, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.23.1+k3s2"
+          default: "v1.25.3+k3s1"
           description: |
               kubernetes version that will be deployed
               for rke: (default: v1.22.5-rancher1-1)
-              for k3s: (default: v1.23.1+k3s2)
+              for rke2: (default: v1.25.3+rke2r1)
+              for k3s: (default: v1.25.3+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/master/sles/longhorn-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/sles/longhorn-tests-sles-arm64.yml
@@ -84,11 +84,12 @@
           description: "kubernetes distro version to install [rke, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.23.1+k3s2"
+          default: "v1.25.3+k3s1"
           description: |
               kubernetes version that will be deployed
               for rke: (default: v1.22.5-rancher1-1)
-              for k3s: (default: v1.23.1+k3s2)
+              for rke2: (default: v1.25.3+rke2r1)
+              for k3s: (default: v1.25.3+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-amd64.yml
@@ -84,11 +84,12 @@
           description: "kubernetes distro version to install [rke, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.23.1+k3s2"
+          default: "v1.25.3+k3s1"
           description: |
               kubernetes version that will be deployed
               for rke: (default: v1.22.5-rancher1-1)
-              for k3s: (default: v1.23.1+k3s2)
+              for rke2: (default: v1.25.3+rke2r1)
+              for k3s: (default: v1.25.3+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-arm64.yml
@@ -84,11 +84,12 @@
           description: "kubernetes distro version to install [rke, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.23.1+k3s2"
+          default: "v1.25.3+k3s1"
           description: |
               kubernetes version that will be deployed
               for rke: (default: v1.22.5-rancher1-1)
-              for k3s: (default: v1.23.1+k3s2)
+              for rke2: (default: v1.25.3+rke2r1)
+              for k3s: (default: v1.25.3+k3s1)
       - string:
           name: DISTRO
           default: "sles"


### PR DESCRIPTION
ci: update default k8s version to v1.25 on master branch

for k3s, update to v1.25.3+k3s1
for rke2, update to v1.25.3+rke2r1
for rke, it doesn't support k8s v1.25 yet

For https://github.com/longhorn/longhorn/issues/4239

Signed-off-by: Yang Chiu <yang.chiu@suse.com>