### PR TITLE
ci: revert master pipeline upgrade test k8s version to < v1.25 to prevent upgrade test failed

### DIFF
--- a/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-amd64.yml
@@ -84,7 +84,7 @@
           description: "kubernetes distro version to install [rke, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.25.3+k3s1"
+          default: "v1.23.1+k3s2"
           description: |
               kubernetes version that will be deployed
               for rke: (default: v1.22.5-rancher1-1)

--- a/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-arm64.yml
@@ -84,7 +84,7 @@
           description: "kubernetes distro version to install [rke, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.25.3+k3s1"
+          default: "v1.23.1+k3s2"
           description: |
               kubernetes version that will be deployed
               for rke: (default: v1.22.5-rancher1-1)


### PR DESCRIPTION
ci: revert master pipeline upgrade test k8s version to < v1.25 to prevent upgrade test failed

because in upgrade test a previous version of longhorn which doesn't support k8s v1.25 will be installed first 

For https://github.com/longhorn/longhorn/issues/4239

Signed-off-by: Yang Chiu <yang.chiu@suse.com>