### PR TITLE
test: add different upgrade paths to cover upgrading from the previous branch release

### DIFF
--- a/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-amd64.yml
@@ -125,5 +125,5 @@
       - parameterized-timer:
           cron: |
             TZ=Asia/Taipei
-            H 21 * * 0,1,3,5 % BACKUP_STORE_TYPE=s3
-            H 21 * * 2,4,6 % BACKUP_STORE_TYPE=nfs
+            H 21 * * 0,1,3,5 % BACKUP_STORE_TYPE=s3;LONGHORN_STABLE_VERSION=v1.2.6
+            H 21 * * 2,4,6 % BACKUP_STORE_TYPE=nfs;LONGHORN_STABLE_VERSION=v1.3.2

--- a/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-arm64.yml
@@ -125,5 +125,5 @@
       - parameterized-timer:
           cron: |
             TZ=Asia/Taipei
-            H 21 * * 0,1,3,5 % BACKUP_STORE_TYPE=s3
-            H 21 * * 2,4,6 % BACKUP_STORE_TYPE=nfs
+            H 21 * * 0,1,3,5 % BACKUP_STORE_TYPE=s3;LONGHORN_STABLE_VERSION=v1.3.2
+            H 21 * * 2,4,6 % BACKUP_STORE_TYPE=nfs;LONGHORN_STABLE_VERSION=v1.2.6

--- a/jenkins-jobs/v1.3.x/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.3.x/longhorn-upgrade-tests-sles-amd64.yml
@@ -124,5 +124,5 @@
       - parameterized-timer:
           cron: |
             TZ=Asia/Taipei
-            H 21 * * 0,1,3,5 % BACKUP_STORE_TYPE=s3
-            H 21 * * 2,4,6 % BACKUP_STORE_TYPE=nfs
+            H 21 * * 0,1,3,5 % BACKUP_STORE_TYPE=s3;LONGHORN_STABLE_VERSION=v1.2.6
+            H 21 * * 2,4,6 % BACKUP_STORE_TYPE=nfs;LONGHORN_STABLE_VERSION=v1.3.2

--- a/jenkins-jobs/v1.3.x/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.3.x/longhorn-upgrade-tests-sles-arm64.yml
@@ -124,5 +124,5 @@
       - parameterized-timer:
           cron: |
             TZ=Asia/Taipei
-            H 21 * * 0,1,3,5 % BACKUP_STORE_TYPE=s3
-            H 21 * * 2,4,6 % BACKUP_STORE_TYPE=nfs
+            H 21 * * 0,1,3,5 % BACKUP_STORE_TYPE=s3;LONGHORN_STABLE_VERSION=v1.3.2
+            H 21 * * 2,4,6 % BACKUP_STORE_TYPE=nfs;LONGHORN_STABLE_VERSION=v1.2.6


### PR DESCRIPTION
test: add different upgrade paths to cover upgrading from the previous branch release

for upgrade to master, 2 upgrade paths are:
(1) v1.2.6 -> master
(2) v1.3.2 -> master

for upgrade to v1.3.x, 2 upgrade paths are:
(1) v1.2.6 -> v1.3.x
(2) v1.3.2 -> v1.3.x

For https://github.com/longhorn/longhorn/issues/4706

Signed-off-by: Yang Chiu <yang.chiu@suse.com>