### PR TITLE
ci: fix duplicated job name causes build jenkins jobs failed

### DIFF
--- a/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-amd64.yml
@@ -1,5 +1,5 @@
 - job:
-    name: longhorn-upgrade-tests-sles-amd64
+    name: longhorn-2-stage-upgrade-tests-sles-amd64
     project-type: pipeline
     folder: public/master/sles/amd64
     parameters:

--- a/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-arm64.yml
@@ -1,5 +1,5 @@
 - job:
-    name: longhorn-upgrade-tests-sles-arm64
+    name: longhorn-2-stage-upgrade-tests-sles-arm64
     project-type: pipeline
     folder: public/master/sles/arm64
     parameters:


### PR DESCRIPTION
ci: fix duplicated job name causes build jenkins jobs failed

Signed-off-by: Yang Chiu <yang.chiu@suse.com>