### PR TITLE
ci: shorten cleanup long-running instances threshold to 1 day

### DIFF
--- a/jenkins-jobs/cleanup-resources.yml
+++ b/jenkins-jobs/cleanup-resources.yml
@@ -26,4 +26,4 @@
     triggers:
       - timed: |-
           TZ=Asia/Taipei
-          0 10 * * 1,4
+          0 10 * * *


### PR DESCRIPTION
ci: shorten cleanup long-running instances threshold to 1 day

Signed-off-by: Yang Chiu <yang.chiu@suse.com>