### PR TITLE
ci: update sles 15 sp4 image version

### DIFF
--- a/jenkins-jobs/longhorn-tests-regression.yml
+++ b/jenkins-jobs/longhorn-tests-regression.yml
@@ -258,11 +258,11 @@
           description: "Linux distro used to install on created instances, supported values: [ubuntu, rhel, sles, centos, oracle, rockylinux]"
       - string:
           name: DISTRO_VERSION
-          default: "15-sp4-v20220621"
+          default: "15-sp4-v20220722"
           description: |
              Linux distro version to install on created instances, choosed based on DISTRO values
              for DISTRO=ubuntu, supported values: [18.04, 20.04, 22.04], default: [22.04]
-             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220621], default: [15-sp4-v20220621]
+             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220722], default: [15-sp4-v20220722]
              for DISTRO=rockylinux, supported values: [8.5, 8.6], default: [8.6]
              for DISTRO=rhel, supported values: [8.4.0, 8.6.0], default: [8.6.0]
              for DISTRO=oracle, supported values: [8.5, 8.6], default: [8.6]

--- a/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-amd64.yml
@@ -99,11 +99,11 @@
           description: "Linux distro used to install on created instances, supported values: [ubuntu, rhel, sles, centos, oracle, rockylinux]"
       - string:
           name: DISTRO_VERSION
-          default: "15-sp4-v20220621"
+          default: "15-sp4-v20220722"
           description: |
              Linux distro version to install on created instances, choosed based on DISTRO values
              for DISTRO=ubuntu, supported values: [18.04, 20.04, 22.04], default: [22.04]
-             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220621], default: [15-sp4-v20220621]
+             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220722], default: [15-sp4-v20220722]
              for DISTRO=rockylinux, supported values: [8.5, 8.6], default: [8.6]
              for DISTRO=rhel, supported values: [8.4.0, 8.6.0], default: [8.6.0]
              for DISTRO=oracle, supported values: [8.5, 8.6], default: [8.6]

--- a/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-arm64.yml
@@ -99,11 +99,11 @@
           description: "Linux distro used to install on created instances, supported values: [ubuntu, rhel, sles, centos, oracle, rockylinux]"
       - string:
           name: DISTRO_VERSION
-          default: "15-sp4-v20220621"
+          default: "15-sp4-v20220722"
           description: |
              Linux distro version to install on created instances, choosed based on DISTRO values
              for DISTRO=ubuntu, supported values: [18.04, 20.04, 22.04], default: [22.04]
-             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220621], default: [15-sp4-v20220621]
+             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220722], default: [15-sp4-v20220722]
              for DISTRO=rockylinux, supported values: [8.5, 8.6], default: [8.6]
              for DISTRO=rhel, supported values: [8.4.0, 8.6.0], default: [8.6.0]
              for DISTRO=oracle, supported values: [8.5, 8.6], default: [8.6]

--- a/jenkins-jobs/master/sles/longhorn-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/sles/longhorn-tests-sles-amd64.yml
@@ -95,11 +95,11 @@
           description: "Linux distro used to install on created instances, supported values: [ubuntu, rhel, sles, centos, oracle, rockylinux]"
       - string:
           name: DISTRO_VERSION
-          default: "15-sp4-v20220621"
+          default: "15-sp4-v20220722"
           description: |
              Linux distro version to install on created instances, choosed based on DISTRO values
              for DISTRO=ubuntu, supported values: [18.04, 20.04, 22.04], default: [22.04]
-             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220621], default: [15-sp4-v20220621]
+             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220722], default: [15-sp4-v20220722]
              for DISTRO=rockylinux, supported values: [8.5, 8.6], default: [8.6]
              for DISTRO=rhel, supported values: [8.4.0, 8.6.0], default: [8.6.0]
              for DISTRO=oracle, supported values: [8.5, 8.6], default: [8.6]

--- a/jenkins-jobs/master/sles/longhorn-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/sles/longhorn-tests-sles-arm64.yml
@@ -95,11 +95,11 @@
           description: "Linux distro used to install on created instances, supported values: [ubuntu, rhel, sles, centos, oracle, rockylinux]"
       - string:
           name: DISTRO_VERSION
-          default: "15-sp4-v20220621"
+          default: "15-sp4-v20220722"
           description: |
              Linux distro version to install on created instances, choosed based on DISTRO values
              for DISTRO=ubuntu, supported values: [18.04, 20.04, 22.04], default: [22.04]
-             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220621], default: [15-sp4-v20220621]
+             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220722], default: [15-sp4-v20220722]
              for DISTRO=rockylinux, supported values: [8.5, 8.6], default: [8.6]
              for DISTRO=rhel, supported values: [8.4.0, 8.6.0], default: [8.6.0]
              for DISTRO=oracle, supported values: [8.5, 8.6], default: [8.6]

--- a/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-amd64.yml
@@ -95,11 +95,11 @@
           description: "Linux distro used to install on created instances, supported values: [ubuntu, rhel, sles, centos, oracle, rockylinux]"
       - string:
           name: DISTRO_VERSION
-          default: "15-sp4-v20220621"
+          default: "15-sp4-v20220722"
           description: |
              Linux distro version to install on created instances, choosed based on DISTRO values
              for DISTRO=ubuntu, supported values: [18.04, 20.04, 22.04], default: [22.04]
-             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220621], default: [15-sp4-v20220621]
+             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220722], default: [15-sp4-v20220722]
              for DISTRO=rockylinux, supported values: [8.5, 8.6], default: [8.6]
              for DISTRO=rhel, supported values: [8.4.0, 8.6.0], default: [8.6.0]
              for DISTRO=oracle, supported values: [8.5, 8.6], default: [8.6]

--- a/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-arm64.yml
@@ -95,11 +95,11 @@
           description: "Linux distro used to install on created instances, supported values: [ubuntu, rhel, sles, centos, oracle, rockylinux]"
       - string:
           name: DISTRO_VERSION
-          default: "15-sp4-v20220621"
+          default: "15-sp4-v20220722"
           description: |
              Linux distro version to install on created instances, choosed based on DISTRO values
              for DISTRO=ubuntu, supported values: [18.04, 20.04, 22.04], default: [22.04]
-             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220621], default: [15-sp4-v20220621]
+             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220722], default: [15-sp4-v20220722]
              for DISTRO=rockylinux, supported values: [8.5, 8.6], default: [8.6]
              for DISTRO=rhel, supported values: [8.4.0, 8.6.0], default: [8.6.0]
              for DISTRO=oracle, supported values: [8.5, 8.6], default: [8.6]

--- a/jenkins-jobs/v1.2.x/longhorn-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.2.x/longhorn-tests-sles-amd64.yml
@@ -95,11 +95,11 @@
           description: "Linux distro used to install on created instances, supported values: [ubuntu, rhel, sles, centos, oracle, rockylinux]"
       - string:
           name: DISTRO_VERSION
-          default: "15-sp4-v20220621"
+          default: "15-sp4-v20220722"
           description: |
              Linux distro version to install on created instances, choosed based on DISTRO values
              for DISTRO=ubuntu, supported values: [18.04, 20.04, 22.04], default: [22.04]
-             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220621], default: [15-sp4-v20220621]
+             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220722], default: [15-sp4-v20220722]
              for DISTRO=rockylinux, supported values: [8.5, 8.6], default: [8.6]
              for DISTRO=rhel, supported values: [8.4.0, 8.6.0], default: [8.6.0]
              for DISTRO=oracle, supported values: [8.5, 8.6], default: [8.6]

--- a/jenkins-jobs/v1.2.x/longhorn-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.2.x/longhorn-tests-sles-arm64.yml
@@ -95,11 +95,11 @@
           description: "Linux distro used to install on created instances, supported values: [ubuntu, rhel, sles, centos, oracle, rockylinux]"
       - string:
           name: DISTRO_VERSION
-          default: "15-sp4-v20220621"
+          default: "15-sp4-v20220722"
           description: |
              Linux distro version to install on created instances, choosed based on DISTRO values
              for DISTRO=ubuntu, supported values: [18.04, 20.04, 22.04], default: [22.04]
-             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220621], default: [15-sp4-v20220621]
+             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220722], default: [15-sp4-v20220722]
              for DISTRO=rockylinux, supported values: [8.5, 8.6], default: [8.6]
              for DISTRO=rhel, supported values: [8.4.0, 8.6.0], default: [8.6.0]
              for DISTRO=oracle, supported values: [8.5, 8.6], default: [8.6]

--- a/jenkins-jobs/v1.2.x/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.2.x/longhorn-upgrade-tests-sles-amd64.yml
@@ -95,11 +95,11 @@
           description: "Linux distro used to install on created instances, supported values: [ubuntu, rhel, sles, centos, oracle, rockylinux]"
       - string:
           name: DISTRO_VERSION
-          default: "15-sp4-v20220621"
+          default: "15-sp4-v20220722"
           description: |
              Linux distro version to install on created instances, choosed based on DISTRO values
              for DISTRO=ubuntu, supported values: [18.04, 20.04, 22.04], default: [22.04]
-             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220621], default: [15-sp4-v20220621]
+             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220722], default: [15-sp4-v20220722]
              for DISTRO=rockylinux, supported values: [8.5, 8.6], default: [8.6]
              for DISTRO=rhel, supported values: [8.4.0, 8.6.0], default: [8.6.0]
              for DISTRO=oracle, supported values: [8.5, 8.6], default: [8.6]

--- a/jenkins-jobs/v1.2.x/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.2.x/longhorn-upgrade-tests-sles-arm64.yml
@@ -95,11 +95,11 @@
           description: "Linux distro used to install on created instances, supported values: [ubuntu, rhel, sles, centos, oracle, rockylinux]"
       - string:
           name: DISTRO_VERSION
-          default: "15-sp4-v20220621"
+          default: "15-sp4-v20220722"
           description: |
              Linux distro version to install on created instances, choosed based on DISTRO values
              for DISTRO=ubuntu, supported values: [18.04, 20.04, 22.04], default: [22.04]
-             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220621], default: [15-sp4-v20220621]
+             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220722], default: [15-sp4-v20220722]
              for DISTRO=rockylinux, supported values: [8.5, 8.6], default: [8.6]
              for DISTRO=rhel, supported values: [8.4.0, 8.6.0], default: [8.6.0]
              for DISTRO=oracle, supported values: [8.5, 8.6], default: [8.6]

--- a/jenkins-jobs/v1.3.x/longhorn-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.3.x/longhorn-tests-sles-amd64.yml
@@ -95,11 +95,11 @@
           description: "Linux distro used to install on created instances, supported values: [ubuntu, rhel, sles, centos, oracle, rockylinux]"
       - string:
           name: DISTRO_VERSION
-          default: "15-sp4-v20220621"
+          default: "15-sp4-v20220722"
           description: |
              Linux distro version to install on created instances, choosed based on DISTRO values
              for DISTRO=ubuntu, supported values: [18.04, 20.04, 22.04], default: [22.04]
-             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220621], default: [15-sp4-v20220621]
+             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220722], default: [15-sp4-v20220722]
              for DISTRO=rockylinux, supported values: [8.5, 8.6], default: [8.6]
              for DISTRO=rhel, supported values: [8.4.0, 8.6.0], default: [8.6.0]
              for DISTRO=oracle, supported values: [8.5, 8.6], default: [8.6]

--- a/jenkins-jobs/v1.3.x/longhorn-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.3.x/longhorn-tests-sles-arm64.yml
@@ -95,11 +95,11 @@
           description: "Linux distro used to install on created instances, supported values: [ubuntu, rhel, sles, centos, oracle, rockylinux]"
       - string:
           name: DISTRO_VERSION
-          default: "15-sp4-v20220621"
+          default: "15-sp4-v20220722"
           description: |
              Linux distro version to install on created instances, choosed based on DISTRO values
              for DISTRO=ubuntu, supported values: [18.04, 20.04, 22.04], default: [22.04]
-             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220621], default: [15-sp4-v20220621]
+             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220722], default: [15-sp4-v20220722]
              for DISTRO=rockylinux, supported values: [8.5, 8.6], default: [8.6]
              for DISTRO=rhel, supported values: [8.4.0, 8.6.0], default: [8.6.0]
              for DISTRO=oracle, supported values: [8.5, 8.6], default: [8.6]

--- a/jenkins-jobs/v1.3.x/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.3.x/longhorn-upgrade-tests-sles-amd64.yml
@@ -95,11 +95,11 @@
           description: "Linux distro used to install on created instances, supported values: [ubuntu, rhel, sles, centos, oracle, rockylinux]"
       - string:
           name: DISTRO_VERSION
-          default: "15-sp4-v20220621"
+          default: "15-sp4-v20220722"
           description: |
              Linux distro version to install on created instances, choosed based on DISTRO values
              for DISTRO=ubuntu, supported values: [18.04, 20.04, 22.04], default: [22.04]
-             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220621], default: [15-sp4-v20220621]
+             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220722], default: [15-sp4-v20220722]
              for DISTRO=rockylinux, supported values: [8.5, 8.6], default: [8.6]
              for DISTRO=rhel, supported values: [8.4.0, 8.6.0], default: [8.6.0]
              for DISTRO=oracle, supported values: [8.5, 8.6], default: [8.6]

--- a/jenkins-jobs/v1.3.x/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.3.x/longhorn-upgrade-tests-sles-arm64.yml
@@ -95,11 +95,11 @@
           description: "Linux distro used to install on created instances, supported values: [ubuntu, rhel, sles, centos, oracle, rockylinux]"
       - string:
           name: DISTRO_VERSION
-          default: "15-sp4-v20220621"
+          default: "15-sp4-v20220722"
           description: |
              Linux distro version to install on created instances, choosed based on DISTRO values
              for DISTRO=ubuntu, supported values: [18.04, 20.04, 22.04], default: [22.04]
-             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220621], default: [15-sp4-v20220621]
+             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220722], default: [15-sp4-v20220722]
              for DISTRO=rockylinux, supported values: [8.5, 8.6], default: [8.6]
              for DISTRO=rhel, supported values: [8.4.0, 8.6.0], default: [8.6.0]
              for DISTRO=oracle, supported values: [8.5, 8.6], default: [8.6]

--- a/jenkins-jobs/v1.4.x/longhorn-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.4.x/longhorn-tests-sles-amd64.yml
@@ -95,11 +95,11 @@
           description: "Linux distro used to install on created instances, supported values: [ubuntu, rhel, sles, centos, oracle, rockylinux]"
       - string:
           name: DISTRO_VERSION
-          default: "15-sp4-v20220621"
+          default: "15-sp4-v20220722"
           description: |
              Linux distro version to install on created instances, choosed based on DISTRO values
              for DISTRO=ubuntu, supported values: [18.04, 20.04, 22.04], default: [22.04]
-             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220621], default: [15-sp4-v20220621]
+             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220722], default: [15-sp4-v20220722]
              for DISTRO=rockylinux, supported values: [8.5, 8.6], default: [8.6]
              for DISTRO=rhel, supported values: [8.4.0, 8.6.0], default: [8.6.0]
              for DISTRO=oracle, supported values: [8.5, 8.6], default: [8.6]

--- a/jenkins-jobs/v1.4.x/longhorn-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.4.x/longhorn-tests-sles-arm64.yml
@@ -95,11 +95,11 @@
           description: "Linux distro used to install on created instances, supported values: [ubuntu, rhel, sles, centos, oracle, rockylinux]"
       - string:
           name: DISTRO_VERSION
-          default: "15-sp4-v20220621"
+          default: "15-sp4-v20220722"
           description: |
              Linux distro version to install on created instances, choosed based on DISTRO values
              for DISTRO=ubuntu, supported values: [18.04, 20.04, 22.04], default: [22.04]
-             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220621], default: [15-sp4-v20220621]
+             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220722], default: [15-sp4-v20220722]
              for DISTRO=rockylinux, supported values: [8.5, 8.6], default: [8.6]
              for DISTRO=rhel, supported values: [8.4.0, 8.6.0], default: [8.6.0]
              for DISTRO=oracle, supported values: [8.5, 8.6], default: [8.6]

--- a/jenkins-jobs/v1.4.x/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.4.x/longhorn-upgrade-tests-sles-amd64.yml
@@ -95,11 +95,11 @@
           description: "Linux distro used to install on created instances, supported values: [ubuntu, rhel, sles, centos, oracle, rockylinux]"
       - string:
           name: DISTRO_VERSION
-          default: "15-sp4-v20220621"
+          default: "15-sp4-v20220722"
           description: |
              Linux distro version to install on created instances, choosed based on DISTRO values
              for DISTRO=ubuntu, supported values: [18.04, 20.04, 22.04], default: [22.04]
-             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220621], default: [15-sp4-v20220621]
+             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220722], default: [15-sp4-v20220722]
              for DISTRO=rockylinux, supported values: [8.5, 8.6], default: [8.6]
              for DISTRO=rhel, supported values: [8.4.0, 8.6.0], default: [8.6.0]
              for DISTRO=oracle, supported values: [8.5, 8.6], default: [8.6]

--- a/jenkins-jobs/v1.4.x/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.4.x/longhorn-upgrade-tests-sles-arm64.yml
@@ -95,11 +95,11 @@
           description: "Linux distro used to install on created instances, supported values: [ubuntu, rhel, sles, centos, oracle, rockylinux]"
       - string:
           name: DISTRO_VERSION
-          default: "15-sp4-v20220621"
+          default: "15-sp4-v20220722"
           description: |
              Linux distro version to install on created instances, choosed based on DISTRO values
              for DISTRO=ubuntu, supported values: [18.04, 20.04, 22.04], default: [22.04]
-             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220621], default: [15-sp4-v20220621]
+             for DISTRO=sles, supported values: [15-sp3-v20210622, 15-sp4-v20220722], default: [15-sp4-v20220722]
              for DISTRO=rockylinux, supported values: [8.5, 8.6], default: [8.6]
              for DISTRO=rhel, supported values: [8.4.0, 8.6.0], default: [8.6.0]
              for DISTRO=oracle, supported values: [8.5, 8.6], default: [8.6]


### PR DESCRIPTION
update sles 15 sp4 image version from 15-sp4-v20220621 to 15-sp4-v20220722, since 15-sp4-v20220621 has been removed.

Signed-off-by: Yang Chiu <yang.chiu@suse.com>