### PR TITLE
ci: run build-engine-test-images automatically

### DIFF
--- a/jenkins-jobs/build-engine-test-images.yml
+++ b/jenkins-jobs/build-engine-test-images.yml
@@ -25,4 +25,9 @@
               - master
       script-path: build_engine_test_images/Jenkinsfile
       lightweight-checkout: true
+    triggers:
+      - parameterized-timer:
+          cron: |
+            TZ=Asia/Taipei
+            0 18 * * 0
 


### PR DESCRIPTION
ci: run build-engine-test-images automatically

For https://github.com/longhorn/longhorn/issues/5400

Signed-off-by: Yang Chiu [yang.chiu@suse.com](mailto:yang.chiu@suse.com)