### PR TITLE
Use obtainable RKE2 version for tests

### DIFF
--- a/jenkins-jobs/longhorn-tests-regression.yml
+++ b/jenkins-jobs/longhorn-tests-regression.yml
@@ -250,7 +250,7 @@
           default: "v1.27.1+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.27.1+rke2r1)
+              for rke2: (default: v1.27.2+rke2r1)
               for k3s: (default: v1.27.1+k3s1)
       - string:
           name: DISTRO

--- a/jenkins-jobs/master/sles/longhorn-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/sles/longhorn-tests-sles-amd64.yml
@@ -87,7 +87,7 @@
           default: "v1.27.1+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.27.1+rke2r1)
+              for rke2: (default: v1.27.2+rke2r1)
               for k3s: (default: v1.27.1+k3s1)
       - string:
           name: DISTRO

--- a/jenkins-jobs/master/sles/longhorn-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/sles/longhorn-tests-sles-arm64.yml
@@ -87,7 +87,7 @@
           default: "v1.27.1+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.27.1+rke2r1)
+              for rke2: (default: v1.27.2+rke2r1)
               for k3s: (default: v1.27.1+k3s1)
       - string:
           name: DISTRO

--- a/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-amd64.yml
@@ -87,7 +87,7 @@
           default: "v1.27.1+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.27.1+rke2r1)
+              for rke2: (default: v1.27.2+rke2r1)
               for k3s: (default: v1.27.1+k3s1)
       - string:
           name: DISTRO

--- a/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-arm64.yml
@@ -87,7 +87,7 @@
           default: "v1.27.1+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.27.1+rke2r1)
+              for rke2: (default: v1.27.2+rke2r1)
               for k3s: (default: v1.27.1+k3s1)
       - string:
           name: DISTRO

--- a/jenkins-jobs/v1.5.x/longhorn-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.5.x/longhorn-tests-sles-amd64.yml
@@ -87,7 +87,7 @@
           default: "v1.27.1+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.27.1+rke2r1)
+              for rke2: (default: v1.27.2+rke2r1)
               for k3s: (default: v1.27.1+k3s1)
       - string:
           name: DISTRO

--- a/jenkins-jobs/v1.5.x/longhorn-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.5.x/longhorn-tests-sles-arm64.yml
@@ -87,7 +87,7 @@
           default: "v1.27.1+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.27.1+rke2r1)
+              for rke2: (default: v1.27.2+rke2r1)
               for k3s: (default: v1.27.1+k3s1)
       - string:
           name: DISTRO

--- a/jenkins-jobs/v1.5.x/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.5.x/longhorn-upgrade-tests-sles-amd64.yml
@@ -87,7 +87,7 @@
           default: "v1.27.1+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.27.1+rke2r1)
+              for rke2: (default: v1.27.2+rke2r1)
               for k3s: (default: v1.27.1+k3s1)
       - string:
           name: DISTRO

--- a/jenkins-jobs/v1.5.x/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.5.x/longhorn-upgrade-tests-sles-arm64.yml
@@ -87,7 +87,7 @@
           default: "v1.27.1+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.27.1+rke2r1)
+              for rke2: (default: v1.27.2+rke2r1)
               for k3s: (default: v1.27.1+k3s1)
       - string:
           name: DISTRO


### PR DESCRIPTION
#longhorn/longhorn#5595

The RKE2 install scripts we use can no longer locate v1.27.1+rke2r1. Use v1.27.2+rke2r1 instead.