### PR TITLE
ci: add cis-1.23 hardening in sles rke2 terraform script

### DIFF
--- a/jenkins-jobs/longhorn-tests-regression.yml
+++ b/jenkins-jobs/longhorn-tests-regression.yml
@@ -281,6 +281,10 @@
           - permissive
           - enforcing
           description: "SELINUX mode [permissive | enforcing] (available only for Rockylinux and RHEL)  default: permissive"
+      - bool:
+          name: CIS_HARDENING
+          default: false
+          description: "setup cis-1.23 hardened environment. effective only when rke2 version > v1.25 and distro = sles"
     pipeline-scm:
       scm:
         - git:


### PR DESCRIPTION
ci: add cis-1.23 hardening in sles rke2 terraform script

For https://github.com/longhorn/longhorn/issues/6092

Signed-off-by: Yang Chiu <yang.chiu@suse.com>