### PR TITLE
update master pipeline upgrade test version

### DIFF
--- a/jenkins-jobs/master/oracle/longhorn-upgrade-tests-oracle-amd64.yml
+++ b/jenkins-jobs/master/oracle/longhorn-upgrade-tests-oracle-amd64.yml
@@ -60,7 +60,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.4.2"
+          default: "v1.5.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/master/rhel/longhorn-upgrade-tests-rhel-amd64.yml
+++ b/jenkins-jobs/master/rhel/longhorn-upgrade-tests-rhel-amd64.yml
@@ -60,7 +60,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.4.2"
+          default: "v1.5.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/master/rhel/longhorn-upgrade-tests-rhel-arm64.yml
+++ b/jenkins-jobs/master/rhel/longhorn-upgrade-tests-rhel-arm64.yml
@@ -60,7 +60,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.4.2"
+          default: "v1.5.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-amd64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-amd64.yml
@@ -60,7 +60,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.4.2"
+          default: "v1.5.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-arm64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-arm64.yml
@@ -60,7 +60,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.4.2"
+          default: "v1.5.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/master/sle-micro/longhorn-upgrade-tests-sle-micro-amd64.yml
+++ b/jenkins-jobs/master/sle-micro/longhorn-upgrade-tests-sle-micro-amd64.yml
@@ -60,7 +60,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.4.2"
+          default: "v1.5.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/master/sle-micro/longhorn-upgrade-tests-sle-micro-arm64.yml
+++ b/jenkins-jobs/master/sle-micro/longhorn-upgrade-tests-sle-micro-arm64.yml
@@ -60,7 +60,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.4.2"
+          default: "v1.5.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-amd64.yml
@@ -60,11 +60,11 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.3.3"
+          default: "v1.4.3"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TRANSIENT_VERSION
-          default: "v1.4.2"
+          default: "v1.5.1"
           description: "transient longhorn version for 2 stage upgrade test. if provided, longhorn will first install the stable version, and then upgrade to this transient version, and finally upgrade to the version to be tested. effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-arm64.yml
@@ -60,11 +60,11 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.3.3"
+          default: "v1.4.3"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TRANSIENT_VERSION
-          default: "v1.4.2"
+          default: "v1.5.1"
           description: "transient longhorn version for 2 stage upgrade test. if provided, longhorn will first install the stable version, and then upgrade to this transient version, and finally upgrade to the version to be tested. effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-amd64.yml
@@ -60,7 +60,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.4.2"
+          default: "v1.5.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-arm64.yml
@@ -60,7 +60,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.4.2"
+          default: "v1.5.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/master/ubuntu/longhorn-upgrade-tests-ubuntu-amd64.yml
+++ b/jenkins-jobs/master/ubuntu/longhorn-upgrade-tests-ubuntu-amd64.yml
@@ -60,7 +60,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.4.2"
+          default: "v1.5.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/master/ubuntu/longhorn-upgrade-tests-ubuntu-arm64.yml
+++ b/jenkins-jobs/master/ubuntu/longhorn-upgrade-tests-ubuntu-arm64.yml
@@ -60,7 +60,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.4.2"
+          default: "v1.5.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER


### PR DESCRIPTION
Update upgrade test version in master pipeline for v1.5.0 released

(1) upgrade test: LONGHORN_STABLE_VERSION=v1.5.0
(2) 2 stage upgrade test: LONGHORN_STABLE_VERSION=v1.4.3, LONGHORN_TRANSIENT_VERSION=v1.5.0