### PR TITLE
ci: add rancher version and longhorn repo name as options in rancher pipeline

### DIFF
--- a/jenkins-jobs/longhorn-rancher-chart-test.yml
+++ b/jenkins-jobs/longhorn-rancher-chart-test.yml
@@ -12,6 +12,10 @@
           default: true
           description: "send slack notification? (default: true)"
       - string:
+          name: RANCHER_VERSION
+          default: ""
+          description: "if empty, latest version will be installed"
+      - string:
           name: RANCHER_CHART_REPO_URI
           default: ""
           description: "rancher chart repo URI"
@@ -19,6 +23,12 @@
           name: RANCHER_CHART_REPO_BRANCH
           default: ""
           description: "rancher chart repo branch"
+      - choice:
+          name: LONGHORN_REPO
+          choices:
+            - rancher
+            - longhornio
+          description: "dockerhub repo of longhorn components"
       - string:
           name: LONGHORN_INSTALL_VERSION
           default: "102.3.0+up1.5.1"


### PR DESCRIPTION
ci: add rancher version and longhorn repo name as options in rancher pipeline

For https://github.com/longhorn/longhorn/issues/3987

Signed-off-by: Yang Chiu <yang.chiu@suse.com>