### PR TITLE
User newer k3s version to avoid checksum offload bug

### DIFF
--- a/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-amd64.yml
@@ -88,11 +88,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.24.8+k3s1"
+          default: "v1.24.16+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.24.8+rke2r1)
-              for k3s: (default: v1.24.8+k3s1)
+              for rke2: (default: v1.24.16+rke2r1)
+              for k3s: (default: v1.24.16+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-arm64.yml
@@ -88,11 +88,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.24.8+k3s1"
+          default: "v1.24.16+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.24.8+rke2r1)
-              for k3s: (default: v1.24.8+k3s1)
+              for rke2: (default: v1.24.16+rke2r1)
+              for k3s: (default: v1.24.16+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/v1.2.x/longhorn-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.2.x/longhorn-tests-sles-amd64.yml
@@ -84,11 +84,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.24.8+k3s1"
+          default: "v1.24.16+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.24.8+rke2r1)
-              for k3s: (default: v1.24.8+k3s1)
+              for rke2: (default: v1.24.16+rke2r1)
+              for k3s: (default: v1.24.16+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/v1.2.x/longhorn-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.2.x/longhorn-tests-sles-arm64.yml
@@ -84,11 +84,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.24.8+k3s1"
+          default: "v1.24.16+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.24.8+rke2r1)
-              for k3s: (default: v1.24.8+k3s1)
+              for rke2: (default: v1.24.16+rke2r1)
+              for k3s: (default: v1.24.16+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/v1.2.x/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.2.x/longhorn-upgrade-tests-sles-amd64.yml
@@ -84,11 +84,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.24.8+k3s1"
+          default: "v1.24.16+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.24.8+rke2r1)
-              for k3s: (default: v1.24.8+k3s1)
+              for rke2: (default: v1.24.16+rke2r1)
+              for k3s: (default: v1.24.16+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/v1.2.x/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.2.x/longhorn-upgrade-tests-sles-arm64.yml
@@ -84,11 +84,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.24.8+k3s1"
+          default: "v1.24.16+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.24.8+rke2r1)
-              for k3s: (default: v1.24.8+k3s1)
+              for rke2: (default: v1.24.16+rke2r1)
+              for k3s: (default: v1.24.16+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/v1.3.x/longhorn-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.3.x/longhorn-tests-sles-amd64.yml
@@ -84,11 +84,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.24.8+k3s1"
+          default: "v1.24.16+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.24.8+rke2r1)
-              for k3s: (default: v1.24.8+k3s1)
+              for rke2: (default: v1.24.16+rke2r1)
+              for k3s: (default: v1.24.16+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/v1.3.x/longhorn-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.3.x/longhorn-tests-sles-arm64.yml
@@ -84,11 +84,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.24.8+k3s1"
+          default: "v1.24.16+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.24.8+rke2r1)
-              for k3s: (default: v1.24.8+k3s1)
+              for rke2: (default: v1.24.16+rke2r1)
+              for k3s: (default: v1.24.16+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/v1.3.x/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.3.x/longhorn-upgrade-tests-sles-amd64.yml
@@ -84,11 +84,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.24.8+k3s1"
+          default: "v1.24.16+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.24.8+rke2r1)
-              for k3s: (default: v1.24.8+k3s1)
+              for rke2: (default: v1.24.16+rke2r1)
+              for k3s: (default: v1.24.16+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/v1.3.x/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.3.x/longhorn-upgrade-tests-sles-arm64.yml
@@ -84,11 +84,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.24.8+k3s1"
+          default: "v1.24.16+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.24.8+rke2r1)
-              for k3s: (default: v1.24.8+k3s1)
+              for rke2: (default: v1.24.16+rke2r1)
+              for k3s: (default: v1.24.16+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/v1.4.x/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.4.x/longhorn-upgrade-tests-sles-amd64.yml
@@ -88,11 +88,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.24.8+k3s1"
+          default: "v1.24.16+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.24.8+rke2r1)
-              for k3s: (default: v1.24.8+k3s1)
+              for rke2: (default: v1.24.16+rke2r1)
+              for k3s: (default: v1.24.16+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/v1.4.x/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.4.x/longhorn-upgrade-tests-sles-arm64.yml
@@ -88,11 +88,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.24.8+k3s1"
+          default: "v1.24.16+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.24.8+rke2r1)
-              for k3s: (default: v1.24.8+k3s1)
+              for rke2: (default: v1.24.16+rke2r1)
+              for k3s: (default: v1.24.16+k3s1)
       - string:
           name: DISTRO
           default: "sles"


### PR DESCRIPTION
longhorn/longhorn#6494

Details in the linked issue, especially:

- https://github.com/longhorn/longhorn/issues/6494#issuecomment-1687171177
- https://github.com/longhorn/longhorn/issues/6494#issuecomment-1686996722

Running https://ci.longhorn.io/job/public/job/v1.3.x/job/v1.3.x-longhorn-tests-sles-amd64/435/ to confirm bumping k3s versions fixes the issue during automated testing.