### PR TITLE
ci: add option to assign public ip to worker nodes

### DIFF
--- a/jenkins-jobs/longhorn-tests-regression.yml
+++ b/jenkins-jobs/longhorn-tests-regression.yml
@@ -292,6 +292,10 @@
           name: CUSTOM_SSH_PUBLIC_KEY
           default: ""
           description: "custom ssh public key for debugging"
+      - bool:
+          name: PUBLIC_WORKER_NODE
+          default: false
+          description: "whether to assign public ip for worker nodes"
     pipeline-scm:
       scm:
         - git:


### PR DESCRIPTION
ci: add option to assign public ip to worker nodes

For https://github.com/longhorn/longhorn/issues/6601

Signed-off-by: Yang Chiu [yang.chiu@suse.com](mailto:yang.chiu@suse.com)