### PR TITLE
test: fix specific test case failure in 2 stage upgrade test by upgrading k8s version

### DIFF
--- a/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-amd64.yml
@@ -91,11 +91,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.24.17+k3s1"
+          default: "v1.28.4+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.24.17+rke2r1)
-              for k3s: (default: v1.24.17+k3s1)
+              for rke2: (default: v1.28.4+rke2r1)
+              for k3s: (default: v1.28.4+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-arm64.yml
@@ -91,11 +91,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.24.17+k3s1"
+          default: "v1.28.4+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.24.17+rke2r1)
-              for k3s: (default: v1.24.17+k3s1)
+              for rke2: (default: v1.28.4+rke2r1)
+              for k3s: (default: v1.28.4+k3s1)
       - string:
           name: DISTRO
           default: "sles"


### PR DESCRIPTION
test: fix test case test_csi_umount_when_longhorn_block_device_is_disconnected_unexpectedly failure in 2 stage upgrade test by upgrading k8s version

For https://github.com/longhorn/longhorn/issues/6533 https://github.com/longhorn/longhorn/issues/3778

Signed-off-by: Yang Chiu <yang.chiu@suse.com>