### PR TITLE
ci: use more cost-effective ec2 instance type

### DIFF
--- a/jenkins-jobs/longhorn-argocd-test.yml
+++ b/jenkins-jobs/longhorn-argocd-test.yml
@@ -90,11 +90,11 @@
             for DISTRO=sle-micro, supported values: [5.3], default: [5.3]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/longhorn-benchmark-test.yml
+++ b/jenkins-jobs/longhorn-benchmark-test.yml
@@ -109,7 +109,7 @@
               since benchmark test doesn't run on control plane, the architecture or the machine type doesn't matter
               light-weight low-cost machine can be used
               for equinix, c3.small.x86 can be used
-              for aws, t2.xlarge can be used
+              for aws, t3.xlarge can be used
       - string:
           name: WORKER_INSTANCE_TYPE
           default: "m3.large.x86"

--- a/jenkins-jobs/longhorn-e2e-test.yml
+++ b/jenkins-jobs/longhorn-e2e-test.yml
@@ -118,11 +118,11 @@
              for DISTRO=sle-micro, supported values: [5.3], default: [5.3]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for worker nodes"
       - choice:
           name: SELINUX_MODE

--- a/jenkins-jobs/longhorn-fleet-test.yml
+++ b/jenkins-jobs/longhorn-fleet-test.yml
@@ -90,11 +90,11 @@
             for DISTRO=sle-micro, supported values: [5.3], default: [5.3]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/longhorn-flux-test.yml
+++ b/jenkins-jobs/longhorn-flux-test.yml
@@ -90,11 +90,11 @@
             for DISTRO=sle-micro, supported values: [5.3], default: [5.3]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/longhorn-helm-chart-test.yml
+++ b/jenkins-jobs/longhorn-helm-chart-test.yml
@@ -118,11 +118,11 @@
              for DISTRO=sle-micro, supported values: [5.3], default: [5.3]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for worker nodes"
       - choice:
           name: SELINUX_MODE

--- a/jenkins-jobs/longhorn-rancher-chart-test.yml
+++ b/jenkins-jobs/longhorn-rancher-chart-test.yml
@@ -104,11 +104,11 @@
             for DISTRO=sle-micro, supported values: [5.3], default: [5.3]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/longhorn-storage-network-test.yml
+++ b/jenkins-jobs/longhorn-storage-network-test.yml
@@ -118,11 +118,11 @@
              for DISTRO=sle-micro, supported values: [5.3], default: [5.3]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for worker nodes"
       - string:
           name: MTU_SIZE

--- a/jenkins-jobs/longhorn-tests-regression.yml
+++ b/jenkins-jobs/longhorn-tests-regression.yml
@@ -272,11 +272,11 @@
              for DISTRO=sle-micro, supported values: [5.5], default: [5.5]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for worker nodes"
       - choice:
           name: SELINUX_MODE

--- a/jenkins-jobs/master/centos/longhorn-tests-centos-amd64.yml
+++ b/jenkins-jobs/master/centos/longhorn-tests-centos-amd64.yml
@@ -106,11 +106,11 @@
              for DISTRO=rockylinux, supported values: [8.8, 9.2], default: [9.2]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for worker nodes"
       - choice:
           name: SELINUX_MODE

--- a/jenkins-jobs/master/centos/longhorn-tests-centos-arm64.yml
+++ b/jenkins-jobs/master/centos/longhorn-tests-centos-arm64.yml
@@ -106,11 +106,11 @@
              for DISTRO=rockylinux, supported values: [8.8, 9.2], default: [9.2]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "a1.xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "a1.xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for worker nodes"
       - choice:
           name: SELINUX_MODE

--- a/jenkins-jobs/master/centos/longhorn-upgrade-tests-centos-amd64.yml
+++ b/jenkins-jobs/master/centos/longhorn-upgrade-tests-centos-amd64.yml
@@ -106,11 +106,11 @@
              for DISTRO=rockylinux, supported values: [8.8, 9.2], default: [9.2]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for worker nodes"
       - choice:
           name: SELINUX_MODE

--- a/jenkins-jobs/master/centos/longhorn-upgrade-tests-centos-arm64.yml
+++ b/jenkins-jobs/master/centos/longhorn-upgrade-tests-centos-arm64.yml
@@ -106,11 +106,11 @@
              for DISTRO=rockylinux, supported values: [8.8, 9.2], default: [9.2]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "a1.xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "a1.xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for worker nodes"
       - choice:
           name: SELINUX_MODE

--- a/jenkins-jobs/master/oracle/longhorn-tests-oracle-amd64.yml
+++ b/jenkins-jobs/master/oracle/longhorn-tests-oracle-amd64.yml
@@ -104,11 +104,11 @@
              for DISTRO=oracle, supported values: [9.1], default: [9.1]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/master/oracle/longhorn-upgrade-tests-oracle-amd64.yml
+++ b/jenkins-jobs/master/oracle/longhorn-upgrade-tests-oracle-amd64.yml
@@ -104,11 +104,11 @@
              for DISTRO=oracle, supported values: [9.1], default: [9.1]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/master/rhel/longhorn-tests-rhel-amd64.yml
+++ b/jenkins-jobs/master/rhel/longhorn-tests-rhel-amd64.yml
@@ -104,11 +104,11 @@
              for DISTRO=rhel, supported values: [9.1.0], default: [9.1.0]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for worker nodes"
       - choice:
           name: SELINUX_MODE

--- a/jenkins-jobs/master/rhel/longhorn-tests-rhel-arm64.yml
+++ b/jenkins-jobs/master/rhel/longhorn-tests-rhel-arm64.yml
@@ -104,11 +104,11 @@
              for DISTRO=rhel, supported values: [9.1.0], default: [9.1.0]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for worker nodes"
       - choice:
           name: SELINUX_MODE

--- a/jenkins-jobs/master/rhel/longhorn-upgrade-tests-rhel-amd64.yml
+++ b/jenkins-jobs/master/rhel/longhorn-upgrade-tests-rhel-amd64.yml
@@ -104,11 +104,11 @@
              for DISTRO=rhel, supported values: [9.1.0], default: [9.1.0]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for worker nodes"
       - choice:
           name: SELINUX_MODE

--- a/jenkins-jobs/master/rhel/longhorn-upgrade-tests-rhel-arm64.yml
+++ b/jenkins-jobs/master/rhel/longhorn-upgrade-tests-rhel-arm64.yml
@@ -104,11 +104,11 @@
              for DISTRO=rhel, supported values: [9.1.0], default: [9.1.0]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for worker nodes"
       - choice:
           name: SELINUX_MODE

--- a/jenkins-jobs/master/rockylinux/longhorn-tests-rockylinux-amd64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-tests-rockylinux-amd64.yml
@@ -104,11 +104,11 @@
              for DISTRO=rockylinux, supported values: [9.3], default: [9.3]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for worker nodes"
       - choice:
           name: SELINUX_MODE

--- a/jenkins-jobs/master/rockylinux/longhorn-tests-rockylinux-arm64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-tests-rockylinux-arm64.yml
@@ -104,11 +104,11 @@
              for DISTRO=rockylinux, supported values: [9.3], default: [9.3]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for worker nodes"
       - choice:
           name: SELINUX_MODE

--- a/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-amd64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-amd64.yml
@@ -104,11 +104,11 @@
              for DISTRO=rockylinux, supported values: [9.3], default: [9.3]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for worker nodes"
       - choice:
           name: SELINUX_MODE

--- a/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-arm64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-arm64.yml
@@ -104,11 +104,11 @@
              for DISTRO=rockylinux, supported values: [9.3], default: [9.3]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for worker nodes"
       - choice:
           name: SELINUX_MODE

--- a/jenkins-jobs/master/sle-micro/longhorn-tests-sle-micro-amd64.yml
+++ b/jenkins-jobs/master/sle-micro/longhorn-tests-sle-micro-amd64.yml
@@ -104,11 +104,11 @@
              for DISTRO=sle-micro, supported values: [5.5], default: [5.5]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/master/sle-micro/longhorn-tests-sle-micro-arm64.yml
+++ b/jenkins-jobs/master/sle-micro/longhorn-tests-sle-micro-arm64.yml
@@ -104,11 +104,11 @@
              for DISTRO=sle-micro, supported values: [5.5], default: [5.5]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/master/sle-micro/longhorn-upgrade-tests-sle-micro-amd64.yml
+++ b/jenkins-jobs/master/sle-micro/longhorn-upgrade-tests-sle-micro-amd64.yml
@@ -104,11 +104,11 @@
              for DISTRO=sle-micro, supported values: [5.5], default: [5.5]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/master/sle-micro/longhorn-upgrade-tests-sle-micro-arm64.yml
+++ b/jenkins-jobs/master/sle-micro/longhorn-upgrade-tests-sle-micro-arm64.yml
@@ -104,11 +104,11 @@
              for DISTRO=sle-micro, supported values: [5.5], default: [5.5]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-amd64.yml
@@ -108,11 +108,11 @@
              for DISTRO=sles, supported values: [15-sp5], default: [15-sp5]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-arm64.yml
@@ -108,11 +108,11 @@
              for DISTRO=sles, supported values: [15-sp5], default: [15-sp5]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/master/sles/longhorn-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/sles/longhorn-tests-sles-amd64.yml
@@ -104,11 +104,11 @@
              for DISTRO=sles, supported values: [15-sp5], default: [15-sp5]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/master/sles/longhorn-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/sles/longhorn-tests-sles-arm64.yml
@@ -104,11 +104,11 @@
              for DISTRO=sles, supported values: [15-sp5], default: [15-sp5]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-amd64.yml
@@ -104,11 +104,11 @@
              for DISTRO=sles, supported values: [15-sp5], default: [15-sp5]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-arm64.yml
@@ -104,11 +104,11 @@
              for DISTRO=sles, supported values: [15-sp5], default: [15-sp5]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/master/ubuntu/longhorn-tests-ubuntu-amd64.yml
+++ b/jenkins-jobs/master/ubuntu/longhorn-tests-ubuntu-amd64.yml
@@ -104,11 +104,11 @@
              for DISTRO=ubuntu, supported values: [22.04], default: [22.04]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/master/ubuntu/longhorn-tests-ubuntu-arm64.yml
+++ b/jenkins-jobs/master/ubuntu/longhorn-tests-ubuntu-arm64.yml
@@ -104,11 +104,11 @@
              for DISTRO=ubuntu, supported values: [22.04], default: [22.04]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/master/ubuntu/longhorn-upgrade-tests-ubuntu-amd64.yml
+++ b/jenkins-jobs/master/ubuntu/longhorn-upgrade-tests-ubuntu-amd64.yml
@@ -104,11 +104,11 @@
              for DISTRO=ubuntu, supported values: [22.04], default: [22.04]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/master/ubuntu/longhorn-upgrade-tests-ubuntu-arm64.yml
+++ b/jenkins-jobs/master/ubuntu/longhorn-upgrade-tests-ubuntu-arm64.yml
@@ -104,11 +104,11 @@
              for DISTRO=ubuntu, supported values: [22.04], default: [22.04]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/v1.1.x/longhorn-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.1.x/longhorn-tests-sles-amd64.yml
@@ -106,11 +106,11 @@
              for DISTRO=rockylinux, supported values: [8.4], default: [8.4]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/v1.1.x/longhorn-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.1.x/longhorn-tests-sles-arm64.yml
@@ -106,11 +106,11 @@
              for DISTRO=rockylinux, supported values: [8.4], default: [8.4]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "a1.xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "a1.xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/v1.1.x/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.1.x/longhorn-upgrade-tests-sles-amd64.yml
@@ -106,11 +106,11 @@
              for DISTRO=rockylinux, supported values: [8.4], default: [8.4]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/v1.1.x/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.1.x/longhorn-upgrade-tests-sles-arm64.yml
@@ -109,11 +109,11 @@
              for DISTRO=rockylinux, supported values: [8.4], default: [8.4]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "a1.xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "a1.xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/v1.2.x/longhorn-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.2.x/longhorn-tests-sles-amd64.yml
@@ -106,11 +106,11 @@
              for DISTRO=centos, supported values: [8.4], default: [8.4]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/v1.2.x/longhorn-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.2.x/longhorn-tests-sles-arm64.yml
@@ -106,11 +106,11 @@
              for DISTRO=centos, supported values: [8.4], default: [8.4]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "a1.xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "a1.xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/v1.2.x/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.2.x/longhorn-upgrade-tests-sles-amd64.yml
@@ -106,11 +106,11 @@
              for DISTRO=centos, supported values: [8.4], default: [8.4]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/v1.2.x/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.2.x/longhorn-upgrade-tests-sles-arm64.yml
@@ -106,11 +106,11 @@
              for DISTRO=centos, supported values: [8.4], default: [8.4]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "a1.xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "a1.xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/v1.3.x/longhorn-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.3.x/longhorn-tests-sles-amd64.yml
@@ -101,11 +101,11 @@
              for DISTRO=sles, supported values: [15-sp5], default: [15-sp5]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/v1.3.x/longhorn-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.3.x/longhorn-tests-sles-arm64.yml
@@ -101,11 +101,11 @@
              for DISTRO=sles, supported values: [15-sp5], default: [15-sp5]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "a1.xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "a1.xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/v1.3.x/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.3.x/longhorn-upgrade-tests-sles-amd64.yml
@@ -101,11 +101,11 @@
              for DISTRO=sles, supported values: [15-sp5], default: [15-sp5]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/v1.3.x/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.3.x/longhorn-upgrade-tests-sles-arm64.yml
@@ -101,11 +101,11 @@
              for DISTRO=sles, supported values: [15-sp5], default: [15-sp5]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "a1.xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "a1.xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/v1.4.x/longhorn-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.4.x/longhorn-tests-sles-amd64.yml
@@ -104,11 +104,11 @@
              for DISTRO=sles, supported values: [15-sp5], default: [15-sp5]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/v1.4.x/longhorn-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.4.x/longhorn-tests-sles-arm64.yml
@@ -104,11 +104,11 @@
              for DISTRO=sles, supported values: [15-sp5], default: [15-sp5]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/v1.4.x/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.4.x/longhorn-upgrade-tests-sles-amd64.yml
@@ -108,11 +108,11 @@
              for DISTRO=sles, supported values: [15-sp5], default: [15-sp5]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/v1.4.x/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.4.x/longhorn-upgrade-tests-sles-arm64.yml
@@ -108,11 +108,11 @@
              for DISTRO=sles, supported values: [15-sp5], default: [15-sp5]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/v1.5.x/longhorn-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.5.x/longhorn-tests-sles-amd64.yml
@@ -104,11 +104,11 @@
              for DISTRO=sles, supported values: [15-sp5], default: [15-sp5]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/v1.5.x/longhorn-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.5.x/longhorn-tests-sles-arm64.yml
@@ -104,11 +104,11 @@
              for DISTRO=sles, supported values: [15-sp5], default: [15-sp5]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/v1.5.x/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.5.x/longhorn-upgrade-tests-sles-amd64.yml
@@ -108,11 +108,11 @@
              for DISTRO=sles, supported values: [15-sp5], default: [15-sp5]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/v1.5.x/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.5.x/longhorn-upgrade-tests-sles-arm64.yml
@@ -108,11 +108,11 @@
              for DISTRO=sles, supported values: [15-sp5], default: [15-sp5]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/v1.6.x/longhorn-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.6.x/longhorn-tests-sles-amd64.yml
@@ -104,11 +104,11 @@
              for DISTRO=sles, supported values: [15-sp5], default: [15-sp5]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/v1.6.x/longhorn-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.6.x/longhorn-tests-sles-arm64.yml
@@ -104,11 +104,11 @@
              for DISTRO=sles, supported values: [15-sp5], default: [15-sp5]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/v1.6.x/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.6.x/longhorn-upgrade-tests-sles-amd64.yml
@@ -108,11 +108,11 @@
              for DISTRO=sles, supported values: [15-sp5], default: [15-sp5]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t3.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/v1.6.x/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.6.x/longhorn-upgrade-tests-sles-arm64.yml
@@ -108,11 +108,11 @@
              for DISTRO=sles, supported values: [15-sp5], default: [15-sp5]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:


### PR DESCRIPTION
ci: use more cost-effective ec2 instance type

For https://github.com/longhorn/longhorn/issues/7957

Signed-off-by: Yang Chiu <yang.chiu@suse.com>