### PR TITLE
test: skip zone related test cases by default when running on aks

### DIFF
--- a/jenkins-jobs/managed-k8s/longhorn-tests-aks.yml
+++ b/jenkins-jobs/managed-k8s/longhorn-tests-aks.yml
@@ -48,7 +48,7 @@
           description: "custom longhorn-manager test image, will be used to run tests"
       - string:
           name: PYTEST_CUSTOM_OPTIONS
-          default: ""
+          default: "--ignore test_zone.py"
           description: "pytest custom options to run specific tests (e.g -k test_hosts)"
       - string:
           name: BACKUP_STORE_TYPE


### PR DESCRIPTION
test: skip zone related test cases by default when running on aks

For https://github.com/longhorn/longhorn/issues/7709

Signed-off-by: Yang Chiu <yang.chiu@suse.com>