### PR TITLE
Update regression job k8s version to v1.29 and LONGHORN_STABLE_VERSIO to v1.6.1.

### DIFF
--- a/jenkins-jobs/longhorn-argocd-test.yml
+++ b/jenkins-jobs/longhorn-argocd-test.yml
@@ -68,11 +68,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.28.4+k3s1"
+          default: "v1.29.3+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.28.4+rke2r1)
-              for k3s: (default: v1.28.4+k3s1)
+              for rke2: (default: v1.29.2+rke2r1)
+              for k3s: (default: v1.29.3+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/longhorn-e2e-test.yml
+++ b/jenkins-jobs/longhorn-e2e-test.yml
@@ -96,11 +96,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.28.4+k3s1"
+          default: "v1.29.3+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.28.4+rke2r1)
-              for k3s: (default: v1.28.4+k3s1)
+              for rke2: (default: v1.29.2+rke2r1)
+              for k3s: (default: v1.29.3+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/longhorn-fleet-test.yml
+++ b/jenkins-jobs/longhorn-fleet-test.yml
@@ -68,11 +68,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.28.4+k3s1"
+          default: "v1.29.3+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.28.4+rke2r1)
-              for k3s: (default: v1.28.4+k3s1)
+              for rke2: (default: v1.29.2+rke2r1)
+              for k3s: (default: v1.29.3+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/longhorn-flux-test.yml
+++ b/jenkins-jobs/longhorn-flux-test.yml
@@ -68,11 +68,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.28.4+k3s1"
+          default: "v1.29.3+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.28.4+rke2r1)
-              for k3s: (default: v1.28.4+k3s1)
+              for rke2: (default: v1.29.2+rke2r1)
+              for k3s: (default: v1.29.3+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/longhorn-helm-chart-test.yml
+++ b/jenkins-jobs/longhorn-helm-chart-test.yml
@@ -68,7 +68,7 @@
           description: "The valid values for this field are 'nfs', 's3' and 'nfs-and-s3'"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.6.0"
+          default: "v1.6.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TRANSIENT_VERSION

--- a/jenkins-jobs/longhorn-helm-chart-test.yml
+++ b/jenkins-jobs/longhorn-helm-chart-test.yml
@@ -96,11 +96,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.28.4+k3s1"
+          default: "v1.29.3+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.28.4+rke2r1)
-              for k3s: (default: v1.28.4+k3s1)
+              for rke2: (default: v1.29.2+rke2r1)
+              for k3s: (default: v1.29.3+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/longhorn-storage-network-test.yml
+++ b/jenkins-jobs/longhorn-storage-network-test.yml
@@ -96,11 +96,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.28.4+k3s1"
+          default: "v1.29.3+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.28.4+rke2r1)
-              for k3s: (default: v1.28.4+k3s1)
+              for rke2: (default: v1.29.2+rke2r1)
+              for k3s: (default: v1.29.3+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/longhorn-tests-regression.yml
+++ b/jenkins-jobs/longhorn-tests-regression.yml
@@ -226,7 +226,7 @@
           description: "The valid values for this field are 'nfs', 's3' and 'nfs-and-s3'"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.6.0"
+          default: "v1.6.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TRANSIENT_VERSION

--- a/jenkins-jobs/longhorn-tests-regression.yml
+++ b/jenkins-jobs/longhorn-tests-regression.yml
@@ -254,11 +254,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.28.4+k3s1"
+          default: "v1.29.3+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.28.4+rke2r1)
-              for k3s: (default: v1.28.4+k3s1)
+              for rke2: (default: v1.29.2+rke2r1)
+              for k3s: (default: v1.29.3+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/managed-k8s/longhorn-tests-aks.yml
+++ b/jenkins-jobs/managed-k8s/longhorn-tests-aks.yml
@@ -63,7 +63,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.6.0"
+          default: "v1.6.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/managed-k8s/longhorn-tests-eks.yml
+++ b/jenkins-jobs/managed-k8s/longhorn-tests-eks.yml
@@ -63,7 +63,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.6.0"
+          default: "v1.6.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/managed-k8s/longhorn-tests-gke.yml
+++ b/jenkins-jobs/managed-k8s/longhorn-tests-gke.yml
@@ -63,7 +63,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.6.0"
+          default: "v1.6.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/master/oracle/longhorn-tests-oracle-amd64.yml
+++ b/jenkins-jobs/master/oracle/longhorn-tests-oracle-amd64.yml
@@ -63,7 +63,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.6.0"
+          default: "v1.6.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/master/oracle/longhorn-tests-oracle-amd64.yml
+++ b/jenkins-jobs/master/oracle/longhorn-tests-oracle-amd64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.28.4+k3s1"
+          default: "v1.29.3+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.28.4+rke2r1)
-              for k3s: (default: v1.28.4+k3s1)
+              for rke2: (default: v1.29.2+rke2r1)
+              for k3s: (default: v1.29.3+k3s1)
       - string:
           name: DISTRO
           default: "oracle"

--- a/jenkins-jobs/master/oracle/longhorn-upgrade-tests-oracle-amd64.yml
+++ b/jenkins-jobs/master/oracle/longhorn-upgrade-tests-oracle-amd64.yml
@@ -63,7 +63,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.6.0"
+          default: "v1.6.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/master/oracle/longhorn-upgrade-tests-oracle-amd64.yml
+++ b/jenkins-jobs/master/oracle/longhorn-upgrade-tests-oracle-amd64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.28.4+k3s1"
+          default: "v1.29.3+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.28.4+rke2r1)
-              for k3s: (default: v1.28.4+k3s1)
+              for rke2: (default: v1.29.2+rke2r1)
+              for k3s: (default: v1.29.3+k3s1)
       - string:
           name: DISTRO
           default: "oracle"

--- a/jenkins-jobs/master/rhel/longhorn-tests-rhel-amd64.yml
+++ b/jenkins-jobs/master/rhel/longhorn-tests-rhel-amd64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.28.4+k3s1"
+          default: "v1.29.3+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.28.4+rke2r1)
-              for k3s: (default: v1.28.4+k3s1)
+              for rke2: (default: v1.29.2+rke2r1)
+              for k3s: (default: v1.29.3+k3s1)
       - string:
           name: DISTRO
           default: "rhel"

--- a/jenkins-jobs/master/rhel/longhorn-tests-rhel-amd64.yml
+++ b/jenkins-jobs/master/rhel/longhorn-tests-rhel-amd64.yml
@@ -63,7 +63,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.6.0"
+          default: "v1.6.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/master/rhel/longhorn-tests-rhel-arm64.yml
+++ b/jenkins-jobs/master/rhel/longhorn-tests-rhel-arm64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.28.4+k3s1"
+          default: "v1.29.3+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.28.4+rke2r1)
-              for k3s: (default: v1.28.4+k3s1)
+              for rke2: (default: v1.29.2+rke2r1)
+              for k3s: (default: v1.29.3+k3s1)
       - string:
           name: DISTRO
           default: "rhel"

--- a/jenkins-jobs/master/rhel/longhorn-tests-rhel-arm64.yml
+++ b/jenkins-jobs/master/rhel/longhorn-tests-rhel-arm64.yml
@@ -63,7 +63,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.6.0"
+          default: "v1.6.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/master/rhel/longhorn-upgrade-tests-rhel-amd64.yml
+++ b/jenkins-jobs/master/rhel/longhorn-upgrade-tests-rhel-amd64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.28.4+k3s1"
+          default: "v1.29.3+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.28.4+rke2r1)
-              for k3s: (default: v1.28.4+k3s1)
+              for rke2: (default: v1.29.2+rke2r1)
+              for k3s: (default: v1.29.3+k3s1)
       - string:
           name: DISTRO
           default: "rhel"

--- a/jenkins-jobs/master/rhel/longhorn-upgrade-tests-rhel-amd64.yml
+++ b/jenkins-jobs/master/rhel/longhorn-upgrade-tests-rhel-amd64.yml
@@ -63,7 +63,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.6.0"
+          default: "v1.6.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/master/rhel/longhorn-upgrade-tests-rhel-arm64.yml
+++ b/jenkins-jobs/master/rhel/longhorn-upgrade-tests-rhel-arm64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.28.4+k3s1"
+          default: "v1.29.3+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.28.4+rke2r1)
-              for k3s: (default: v1.28.4+k3s1)
+              for rke2: (default: v1.29.2+rke2r1)
+              for k3s: (default: v1.29.3+k3s1)
       - string:
           name: DISTRO
           default: "rhel"

--- a/jenkins-jobs/master/rhel/longhorn-upgrade-tests-rhel-arm64.yml
+++ b/jenkins-jobs/master/rhel/longhorn-upgrade-tests-rhel-arm64.yml
@@ -63,7 +63,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.6.0"
+          default: "v1.6.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/master/rockylinux/longhorn-tests-rockylinux-amd64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-tests-rockylinux-amd64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.28.4+k3s1"
+          default: "v1.29.3+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.28.4+rke2r1)
-              for k3s: (default: v1.28.4+k3s1)
+              for rke2: (default: v1.29.2+rke2r1)
+              for k3s: (default: v1.29.3+k3s1)
       - string:
           name: DISTRO
           default: "rockylinux"

--- a/jenkins-jobs/master/rockylinux/longhorn-tests-rockylinux-amd64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-tests-rockylinux-amd64.yml
@@ -63,7 +63,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.6.0"
+          default: "v1.6.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/master/rockylinux/longhorn-tests-rockylinux-arm64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-tests-rockylinux-arm64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.28.4+k3s1"
+          default: "v1.29.3+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.28.4+rke2r1)
-              for k3s: (default: v1.28.4+k3s1)
+              for rke2: (default: v1.29.2+rke2r1)
+              for k3s: (default: v1.29.3+k3s1)
       - string:
           name: DISTRO
           default: "rockylinux"

--- a/jenkins-jobs/master/rockylinux/longhorn-tests-rockylinux-arm64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-tests-rockylinux-arm64.yml
@@ -63,7 +63,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.6.0"
+          default: "v1.6.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-amd64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-amd64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.28.4+k3s1"
+          default: "v1.29.3+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.28.4+rke2r1)
-              for k3s: (default: v1.28.4+k3s1)
+              for rke2: (default: v1.29.2+rke2r1)
+              for k3s: (default: v1.29.3+k3s1)
       - string:
           name: DISTRO
           default: "rockylinux"

--- a/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-amd64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-amd64.yml
@@ -63,7 +63,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.6.0"
+          default: "v1.6.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-arm64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-arm64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.28.4+k3s1"
+          default: "v1.29.3+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.28.4+rke2r1)
-              for k3s: (default: v1.28.4+k3s1)
+              for rke2: (default: v1.29.2+rke2r1)
+              for k3s: (default: v1.29.3+k3s1)
       - string:
           name: DISTRO
           default: "rockylinux"

--- a/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-arm64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-arm64.yml
@@ -63,7 +63,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.6.0"
+          default: "v1.6.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/master/sle-micro/longhorn-tests-sle-micro-amd64.yml
+++ b/jenkins-jobs/master/sle-micro/longhorn-tests-sle-micro-amd64.yml
@@ -63,7 +63,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.6.0"
+          default: "v1.6.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/master/sle-micro/longhorn-tests-sle-micro-amd64.yml
+++ b/jenkins-jobs/master/sle-micro/longhorn-tests-sle-micro-amd64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.28.4+k3s1"
+          default: "v1.29.3+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.28.4+rke2r1)
-              for k3s: (default: v1.28.4+k3s1)
+              for rke2: (default: v1.29.2+rke2r1)
+              for k3s: (default: v1.29.3+k3s1)
       - string:
           name: DISTRO
           default: "sle-micro"

--- a/jenkins-jobs/master/sle-micro/longhorn-tests-sle-micro-arm64.yml
+++ b/jenkins-jobs/master/sle-micro/longhorn-tests-sle-micro-arm64.yml
@@ -63,7 +63,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.6.0"
+          default: "v1.6.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/master/sle-micro/longhorn-tests-sle-micro-arm64.yml
+++ b/jenkins-jobs/master/sle-micro/longhorn-tests-sle-micro-arm64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.28.4+k3s1"
+          default: "v1.29.3+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.28.4+rke2r1)
-              for k3s: (default: v1.28.4+k3s1)
+              for rke2: (default: v1.29.2+rke2r1)
+              for k3s: (default: v1.29.3+k3s1)
       - string:
           name: DISTRO
           default: "sle-micro"

--- a/jenkins-jobs/master/sle-micro/longhorn-upgrade-tests-sle-micro-amd64.yml
+++ b/jenkins-jobs/master/sle-micro/longhorn-upgrade-tests-sle-micro-amd64.yml
@@ -63,7 +63,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.6.0"
+          default: "v1.6.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/master/sle-micro/longhorn-upgrade-tests-sle-micro-amd64.yml
+++ b/jenkins-jobs/master/sle-micro/longhorn-upgrade-tests-sle-micro-amd64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.28.4+k3s1"
+          default: "v1.29.3+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.28.4+rke2r1)
-              for k3s: (default: v1.28.4+k3s1)
+              for rke2: (default: v1.29.2+rke2r1)
+              for k3s: (default: v1.29.3+k3s1)
       - string:
           name: DISTRO
           default: "sle-micro"

--- a/jenkins-jobs/master/sle-micro/longhorn-upgrade-tests-sle-micro-arm64.yml
+++ b/jenkins-jobs/master/sle-micro/longhorn-upgrade-tests-sle-micro-arm64.yml
@@ -63,7 +63,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.6.0"
+          default: "v1.6.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/master/sle-micro/longhorn-upgrade-tests-sle-micro-arm64.yml
+++ b/jenkins-jobs/master/sle-micro/longhorn-upgrade-tests-sle-micro-arm64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.28.4+k3s1"
+          default: "v1.29.3+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.28.4+rke2r1)
-              for k3s: (default: v1.28.4+k3s1)
+              for rke2: (default: v1.29.2+rke2r1)
+              for k3s: (default: v1.29.3+k3s1)
       - string:
           name: DISTRO
           default: "sle-micro"

--- a/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-amd64.yml
@@ -67,7 +67,7 @@
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TRANSIENT_VERSION
-          default: "v1.6.0"
+          default: "v1.6.1"
           description: "transient longhorn version for 2 stage upgrade test. if provided, longhorn will first install the stable version, and then upgrade to this transient version, and finally upgrade to the version to be tested. effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-amd64.yml
@@ -91,11 +91,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.28.4+k3s1"
+          default: "v1.29.3+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.28.4+rke2r1)
-              for k3s: (default: v1.28.4+k3s1)
+              for rke2: (default: v1.29.2+rke2r1)
+              for k3s: (default: v1.29.3+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-arm64.yml
@@ -67,7 +67,7 @@
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TRANSIENT_VERSION
-          default: "v1.6.0"
+          default: "v1.6.1"
           description: "transient longhorn version for 2 stage upgrade test. if provided, longhorn will first install the stable version, and then upgrade to this transient version, and finally upgrade to the version to be tested. effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-arm64.yml
@@ -91,11 +91,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.28.4+k3s1"
+          default: "v1.29.3+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.28.4+rke2r1)
-              for k3s: (default: v1.28.4+k3s1)
+              for rke2: (default: v1.29.2+rke2r1)
+              for k3s: (default: v1.29.3+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/master/sles/longhorn-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/sles/longhorn-tests-sles-amd64.yml
@@ -63,7 +63,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.6.0"
+          default: "v1.6.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/master/sles/longhorn-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/sles/longhorn-tests-sles-amd64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.28.4+k3s1"
+          default: "v1.29.3+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.28.4+rke2r1)
-              for k3s: (default: v1.28.4+k3s1)
+              for rke2: (default: v1.29.2+rke2r1)
+              for k3s: (default: v1.29.3+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/master/sles/longhorn-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/sles/longhorn-tests-sles-arm64.yml
@@ -63,7 +63,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.6.0"
+          default: "v1.6.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/master/sles/longhorn-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/sles/longhorn-tests-sles-arm64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.28.4+k3s1"
+          default: "v1.29.3+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.28.4+rke2r1)
-              for k3s: (default: v1.28.4+k3s1)
+              for rke2: (default: v1.29.2+rke2r1)
+              for k3s: (default: v1.29.3+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-amd64.yml
@@ -63,7 +63,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.6.0"
+          default: "v1.6.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-amd64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.28.4+k3s1"
+          default: "v1.29.3+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.28.4+rke2r1)
-              for k3s: (default: v1.28.4+k3s1)
+              for rke2: (default: v1.29.2+rke2r1)
+              for k3s: (default: v1.29.3+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-arm64.yml
@@ -63,7 +63,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.6.0"
+          default: "v1.6.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-arm64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.28.4+k3s1"
+          default: "v1.29.3+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.28.4+rke2r1)
-              for k3s: (default: v1.28.4+k3s1)
+              for rke2: (default: v1.29.2+rke2r1)
+              for k3s: (default: v1.29.3+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/master/ubuntu/longhorn-tests-ubuntu-amd64.yml
+++ b/jenkins-jobs/master/ubuntu/longhorn-tests-ubuntu-amd64.yml
@@ -63,7 +63,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.6.0"
+          default: "v1.6.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/master/ubuntu/longhorn-tests-ubuntu-amd64.yml
+++ b/jenkins-jobs/master/ubuntu/longhorn-tests-ubuntu-amd64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.28.4+k3s1"
+          default: "v1.29.3+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.28.4+rke2r1)
-              for k3s: (default: v1.28.4+k3s1)
+              for rke2: (default: v1.29.2+rke2r1)
+              for k3s: (default: v1.29.3+k3s1)
       - string:
           name: DISTRO
           default: "ubuntu"

--- a/jenkins-jobs/master/ubuntu/longhorn-tests-ubuntu-arm64.yml
+++ b/jenkins-jobs/master/ubuntu/longhorn-tests-ubuntu-arm64.yml
@@ -63,7 +63,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.6.0"
+          default: "v1.6.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/master/ubuntu/longhorn-tests-ubuntu-arm64.yml
+++ b/jenkins-jobs/master/ubuntu/longhorn-tests-ubuntu-arm64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.28.4+k3s1"
+          default: "v1.29.3+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.28.4+rke2r1)
-              for k3s: (default: v1.28.4+k3s1)
+              for rke2: (default: v1.29.2+rke2r1)
+              for k3s: (default: v1.29.3+k3s1)
       - string:
           name: DISTRO
           default: "ubuntu"

--- a/jenkins-jobs/master/ubuntu/longhorn-upgrade-tests-ubuntu-amd64.yml
+++ b/jenkins-jobs/master/ubuntu/longhorn-upgrade-tests-ubuntu-amd64.yml
@@ -63,7 +63,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.6.0"
+          default: "v1.6.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/master/ubuntu/longhorn-upgrade-tests-ubuntu-amd64.yml
+++ b/jenkins-jobs/master/ubuntu/longhorn-upgrade-tests-ubuntu-amd64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.28.4+k3s1"
+          default: "v1.29.3+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.28.4+rke2r1)
-              for k3s: (default: v1.28.4+k3s1)
+              for rke2: (default: v1.29.2+rke2r1)
+              for k3s: (default: v1.29.3+k3s1)
       - string:
           name: DISTRO
           default: "ubuntu"

--- a/jenkins-jobs/master/ubuntu/longhorn-upgrade-tests-ubuntu-arm64.yml
+++ b/jenkins-jobs/master/ubuntu/longhorn-upgrade-tests-ubuntu-arm64.yml
@@ -63,7 +63,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.6.0"
+          default: "v1.6.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/master/ubuntu/longhorn-upgrade-tests-ubuntu-arm64.yml
+++ b/jenkins-jobs/master/ubuntu/longhorn-upgrade-tests-ubuntu-arm64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.28.4+k3s1"
+          default: "v1.29.3+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.28.4+rke2r1)
-              for k3s: (default: v1.28.4+k3s1)
+              for rke2: (default: v1.29.2+rke2r1)
+              for k3s: (default: v1.29.3+k3s1)
       - string:
           name: DISTRO
           default: "ubuntu"

--- a/jenkins-jobs/v1.6.x/longhorn-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.6.x/longhorn-tests-sles-amd64.yml
@@ -63,7 +63,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.6.0"
+          default: "v1.6.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/v1.6.x/longhorn-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.6.x/longhorn-tests-sles-arm64.yml
@@ -63,7 +63,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.6.0"
+          default: "v1.6.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TEST_CLOUDPROVIDER

--- a/jenkins-jobs/v1.6.x/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.6.x/longhorn-upgrade-tests-sles-amd64.yml
@@ -63,7 +63,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.6.0"
+          default: "v1.6.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TRANSIENT_VERSION
@@ -127,4 +127,4 @@
           cron: |
             TZ=Asia/Taipei
             H 19 * * 0,1,3,5 % BACKUP_STORE_TYPE=s3;LONGHORN_STABLE_VERSION=v1.5.4
-            H 19 * * 2,4,6 % BACKUP_STORE_TYPE=nfs;LONGHORN_STABLE_VERSION=v1.6.0
+            H 19 * * 2,4,6 % BACKUP_STORE_TYPE=nfs;LONGHORN_STABLE_VERSION=v1.6.1

--- a/jenkins-jobs/v1.6.x/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.6.x/longhorn-upgrade-tests-sles-arm64.yml
@@ -63,7 +63,7 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: LONGHORN_STABLE_VERSION
-          default: "v1.6.0"
+          default: "v1.6.1"
           description: "longhorn version that will be installed before upgrade, effective only when LONGHORN_UPGRADE_TEST is TRUE"
       - string:
           name: LONGHORN_TRANSIENT_VERSION
@@ -127,4 +127,4 @@
           cron: |
             TZ=Asia/Taipei
             H 19 * * 0,1,3,5 % BACKUP_STORE_TYPE=s3;LONGHORN_STABLE_VERSION=v1.5.4
-            H 19 * * 2,4,6 % BACKUP_STORE_TYPE=nfs;LONGHORN_STABLE_VERSION=v1.6.0
+            H 19 * * 2,4,6 % BACKUP_STORE_TYPE=nfs;LONGHORN_STABLE_VERSION=v1.6.1


### PR DESCRIPTION
1. Update `v1.6.x`/`master` LONGHORN_STABLE_VERSION to `v1.6.1`
2. Update regression job k8s version to `v1.29`

ref. https://github.com/longhorn/longhorn/issues/8239

Signed-off-by: Roger Yao <roger.yao@suse.com>