### PR TITLE
Update regression job k8s version to v1.30

### DIFF
--- a/jenkins-jobs/longhorn-argocd-test.yml
+++ b/jenkins-jobs/longhorn-argocd-test.yml
@@ -68,11 +68,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.29.3+k3s1"
+          default: "v1.30.0+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.29.2+rke2r1)
-              for k3s: (default: v1.29.3+k3s1)
+              for rke2: (default: v1.30.0+rke2r1)
+              for k3s: (default: v1.30.0+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/longhorn-benchmark-test.yml
+++ b/jenkins-jobs/longhorn-benchmark-test.yml
@@ -83,11 +83,11 @@
               for arm64, since rke2 doesn't support arm64, only k3s can be used
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.24.7+rke2r1"
+          default: "v1.30.0+rke2r1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.24.7+rke2r1)
-              for k3s: (default: v1.24.7+k3s1)
+              for rke2: (default: v1.30.0+rke2r1)
+              for k3s: (default: v1.30.0+k3s1)
       - string:
           name: DISTRO
           default: "ubuntu"

--- a/jenkins-jobs/longhorn-e2e-test.yml
+++ b/jenkins-jobs/longhorn-e2e-test.yml
@@ -96,11 +96,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.29.3+k3s1"
+          default: "v1.30.0+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.29.2+rke2r1)
-              for k3s: (default: v1.29.3+k3s1)
+              for rke2: (default: v1.30.0+rke2r1)
+              for k3s: (default: v1.30.0+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/longhorn-fleet-test.yml
+++ b/jenkins-jobs/longhorn-fleet-test.yml
@@ -68,11 +68,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.29.3+k3s1"
+          default: "v1.30.0+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.29.2+rke2r1)
-              for k3s: (default: v1.29.3+k3s1)
+              for rke2: (default: v1.30.0+rke2r1)
+              for k3s: (default: v1.30.0+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/longhorn-flux-test.yml
+++ b/jenkins-jobs/longhorn-flux-test.yml
@@ -68,11 +68,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.29.3+k3s1"
+          default: "v1.30.0+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.29.2+rke2r1)
-              for k3s: (default: v1.29.3+k3s1)
+              for rke2: (default: v1.30.0+rke2r1)
+              for k3s: (default: v1.30.0+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/longhorn-helm-chart-test.yml
+++ b/jenkins-jobs/longhorn-helm-chart-test.yml
@@ -96,11 +96,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.29.3+k3s1"
+          default: "v1.30.0+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.29.2+rke2r1)
-              for k3s: (default: v1.29.3+k3s1)
+              for rke2: (default: v1.30.0+rke2r1)
+              for k3s: (default: v1.30.0+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/longhorn-storage-network-test.yml
+++ b/jenkins-jobs/longhorn-storage-network-test.yml
@@ -96,11 +96,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.29.3+k3s1"
+          default: "v1.30.0+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.29.2+rke2r1)
-              for k3s: (default: v1.29.3+k3s1)
+              for rke2: (default: v1.30.0+rke2r1)
+              for k3s: (default: v1.30.0+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/longhorn-tests-regression.yml
+++ b/jenkins-jobs/longhorn-tests-regression.yml
@@ -254,11 +254,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.29.3+k3s1"
+          default: "v1.30.0+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.29.2+rke2r1)
-              for k3s: (default: v1.29.3+k3s1)
+              for rke2: (default: v1.30.0+rke2r1)
+              for k3s: (default: v1.30.0+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/master/oracle/longhorn-tests-oracle-amd64.yml
+++ b/jenkins-jobs/master/oracle/longhorn-tests-oracle-amd64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.29.3+k3s1"
+          default: "v1.30.0+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.29.2+rke2r1)
-              for k3s: (default: v1.29.3+k3s1)
+              for rke2: (default: v1.30.0+rke2r1)
+              for k3s: (default: v1.30.0+k3s1)
       - string:
           name: DISTRO
           default: "oracle"

--- a/jenkins-jobs/master/oracle/longhorn-upgrade-tests-oracle-amd64.yml
+++ b/jenkins-jobs/master/oracle/longhorn-upgrade-tests-oracle-amd64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.29.3+k3s1"
+          default: "v1.30.0+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.29.2+rke2r1)
-              for k3s: (default: v1.29.3+k3s1)
+              for rke2: (default: v1.30.0+rke2r1)
+              for k3s: (default: v1.30.0+k3s1)
       - string:
           name: DISTRO
           default: "oracle"

--- a/jenkins-jobs/master/rhel/longhorn-tests-rhel-amd64.yml
+++ b/jenkins-jobs/master/rhel/longhorn-tests-rhel-amd64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.29.3+k3s1"
+          default: "v1.30.0+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.29.2+rke2r1)
-              for k3s: (default: v1.29.3+k3s1)
+              for rke2: (default: v1.30.0+rke2r1)
+              for k3s: (default: v1.30.0+k3s1)
       - string:
           name: DISTRO
           default: "rhel"

--- a/jenkins-jobs/master/rhel/longhorn-tests-rhel-arm64.yml
+++ b/jenkins-jobs/master/rhel/longhorn-tests-rhel-arm64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.29.3+k3s1"
+          default: "v1.30.0+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.29.2+rke2r1)
-              for k3s: (default: v1.29.3+k3s1)
+              for rke2: (default: v1.30.0+rke2r1)
+              for k3s: (default: v1.30.0+k3s1)
       - string:
           name: DISTRO
           default: "rhel"

--- a/jenkins-jobs/master/rhel/longhorn-upgrade-tests-rhel-amd64.yml
+++ b/jenkins-jobs/master/rhel/longhorn-upgrade-tests-rhel-amd64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.29.3+k3s1"
+          default: "v1.30.0+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.29.2+rke2r1)
-              for k3s: (default: v1.29.3+k3s1)
+              for rke2: (default: v1.30.0+rke2r1)
+              for k3s: (default: v1.30.0+k3s1)
       - string:
           name: DISTRO
           default: "rhel"

--- a/jenkins-jobs/master/rhel/longhorn-upgrade-tests-rhel-arm64.yml
+++ b/jenkins-jobs/master/rhel/longhorn-upgrade-tests-rhel-arm64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.29.3+k3s1"
+          default: "v1.30.0+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.29.2+rke2r1)
-              for k3s: (default: v1.29.3+k3s1)
+              for rke2: (default: v1.30.0+rke2r1)
+              for k3s: (default: v1.30.0+k3s1)
       - string:
           name: DISTRO
           default: "rhel"

--- a/jenkins-jobs/master/rockylinux/longhorn-tests-rockylinux-amd64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-tests-rockylinux-amd64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.29.3+k3s1"
+          default: "v1.30.0+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.29.2+rke2r1)
-              for k3s: (default: v1.29.3+k3s1)
+              for rke2: (default: v1.30.0+rke2r1)
+              for k3s: (default: v1.30.0+k3s1)
       - string:
           name: DISTRO
           default: "rockylinux"

--- a/jenkins-jobs/master/rockylinux/longhorn-tests-rockylinux-arm64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-tests-rockylinux-arm64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.29.3+k3s1"
+          default: "v1.30.0+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.29.2+rke2r1)
-              for k3s: (default: v1.29.3+k3s1)
+              for rke2: (default: v1.30.0+rke2r1)
+              for k3s: (default: v1.30.0+k3s1)
       - string:
           name: DISTRO
           default: "rockylinux"

--- a/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-amd64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-amd64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.29.3+k3s1"
+          default: "v1.30.0+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.29.2+rke2r1)
-              for k3s: (default: v1.29.3+k3s1)
+              for rke2: (default: v1.30.0+rke2r1)
+              for k3s: (default: v1.30.0+k3s1)
       - string:
           name: DISTRO
           default: "rockylinux"

--- a/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-arm64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-arm64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.29.3+k3s1"
+          default: "v1.30.0+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.29.2+rke2r1)
-              for k3s: (default: v1.29.3+k3s1)
+              for rke2: (default: v1.30.0+rke2r1)
+              for k3s: (default: v1.30.0+k3s1)
       - string:
           name: DISTRO
           default: "rockylinux"

--- a/jenkins-jobs/master/sle-micro/longhorn-tests-sle-micro-amd64.yml
+++ b/jenkins-jobs/master/sle-micro/longhorn-tests-sle-micro-amd64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.29.3+k3s1"
+          default: "v1.30.0+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.29.2+rke2r1)
-              for k3s: (default: v1.29.3+k3s1)
+              for rke2: (default: v1.30.0+rke2r1)
+              for k3s: (default: v1.30.0+k3s1)
       - string:
           name: DISTRO
           default: "sle-micro"

--- a/jenkins-jobs/master/sle-micro/longhorn-tests-sle-micro-arm64.yml
+++ b/jenkins-jobs/master/sle-micro/longhorn-tests-sle-micro-arm64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.29.3+k3s1"
+          default: "v1.30.0+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.29.2+rke2r1)
-              for k3s: (default: v1.29.3+k3s1)
+              for rke2: (default: v1.30.0+rke2r1)
+              for k3s: (default: v1.30.0+k3s1)
       - string:
           name: DISTRO
           default: "sle-micro"

--- a/jenkins-jobs/master/sle-micro/longhorn-upgrade-tests-sle-micro-amd64.yml
+++ b/jenkins-jobs/master/sle-micro/longhorn-upgrade-tests-sle-micro-amd64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.29.3+k3s1"
+          default: "v1.30.0+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.29.2+rke2r1)
-              for k3s: (default: v1.29.3+k3s1)
+              for rke2: (default: v1.30.0+rke2r1)
+              for k3s: (default: v1.30.0+k3s1)
       - string:
           name: DISTRO
           default: "sle-micro"

--- a/jenkins-jobs/master/sle-micro/longhorn-upgrade-tests-sle-micro-arm64.yml
+++ b/jenkins-jobs/master/sle-micro/longhorn-upgrade-tests-sle-micro-arm64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.29.3+k3s1"
+          default: "v1.30.0+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.29.2+rke2r1)
-              for k3s: (default: v1.29.3+k3s1)
+              for rke2: (default: v1.30.0+rke2r1)
+              for k3s: (default: v1.30.0+k3s1)
       - string:
           name: DISTRO
           default: "sle-micro"

--- a/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-amd64.yml
@@ -91,11 +91,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.29.3+k3s1"
+          default: "v1.30.0+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.29.2+rke2r1)
-              for k3s: (default: v1.29.3+k3s1)
+              for rke2: (default: v1.30.0+rke2r1)
+              for k3s: (default: v1.30.0+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-arm64.yml
@@ -91,11 +91,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.29.3+k3s1"
+          default: "v1.30.0+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.29.2+rke2r1)
-              for k3s: (default: v1.29.3+k3s1)
+              for rke2: (default: v1.30.0+rke2r1)
+              for k3s: (default: v1.30.0+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/master/sles/longhorn-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/sles/longhorn-tests-sles-amd64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.29.3+k3s1"
+          default: "v1.30.0+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.29.2+rke2r1)
-              for k3s: (default: v1.29.3+k3s1)
+              for rke2: (default: v1.30.0+rke2r1)
+              for k3s: (default: v1.30.0+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/master/sles/longhorn-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/sles/longhorn-tests-sles-arm64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.29.3+k3s1"
+          default: "v1.30.0+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.29.2+rke2r1)
-              for k3s: (default: v1.29.3+k3s1)
+              for rke2: (default: v1.30.0+rke2r1)
+              for k3s: (default: v1.30.0+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-amd64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.29.3+k3s1"
+          default: "v1.30.0+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.29.2+rke2r1)
-              for k3s: (default: v1.29.3+k3s1)
+              for rke2: (default: v1.30.0+rke2r1)
+              for k3s: (default: v1.30.0+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-arm64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.29.3+k3s1"
+          default: "v1.30.0+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.29.2+rke2r1)
-              for k3s: (default: v1.29.3+k3s1)
+              for rke2: (default: v1.30.0+rke2r1)
+              for k3s: (default: v1.30.0+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/master/ubuntu/longhorn-tests-ubuntu-amd64.yml
+++ b/jenkins-jobs/master/ubuntu/longhorn-tests-ubuntu-amd64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.29.3+k3s1"
+          default: "v1.30.0+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.29.2+rke2r1)
-              for k3s: (default: v1.29.3+k3s1)
+              for rke2: (default: v1.30.0+rke2r1)
+              for k3s: (default: v1.30.0+k3s1)
       - string:
           name: DISTRO
           default: "ubuntu"

--- a/jenkins-jobs/master/ubuntu/longhorn-tests-ubuntu-arm64.yml
+++ b/jenkins-jobs/master/ubuntu/longhorn-tests-ubuntu-arm64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.29.3+k3s1"
+          default: "v1.30.0+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.29.2+rke2r1)
-              for k3s: (default: v1.29.3+k3s1)
+              for rke2: (default: v1.30.0+rke2r1)
+              for k3s: (default: v1.30.0+k3s1)
       - string:
           name: DISTRO
           default: "ubuntu"

--- a/jenkins-jobs/master/ubuntu/longhorn-upgrade-tests-ubuntu-amd64.yml
+++ b/jenkins-jobs/master/ubuntu/longhorn-upgrade-tests-ubuntu-amd64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.29.3+k3s1"
+          default: "v1.30.0+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.29.2+rke2r1)
-              for k3s: (default: v1.29.3+k3s1)
+              for rke2: (default: v1.30.0+rke2r1)
+              for k3s: (default: v1.30.0+k3s1)
       - string:
           name: DISTRO
           default: "ubuntu"

--- a/jenkins-jobs/master/ubuntu/longhorn-upgrade-tests-ubuntu-arm64.yml
+++ b/jenkins-jobs/master/ubuntu/longhorn-upgrade-tests-ubuntu-arm64.yml
@@ -87,11 +87,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.29.3+k3s1"
+          default: "v1.30.0+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.29.2+rke2r1)
-              for k3s: (default: v1.29.3+k3s1)
+              for rke2: (default: v1.30.0+rke2r1)
+              for k3s: (default: v1.30.0+k3s1)
       - string:
           name: DISTRO
           default: "ubuntu"


### PR DESCRIPTION
ref. longhorn/longhorn#8239

The test result for v1.30.0+rke2r1.
https://ci.longhorn.io/job/private/job/longhorn-tests-regression/6983/ 
![Screenshot_20240603_162609](https://github.com/longhorn/infra/assets/104337648/ca451138-fe43-4877-9098-90ccd9638a24)


The test result for v1.30.0+k3s1.
https://ci.longhorn.io/job/private/job/longhorn-tests-regression/6962/ 
![Screenshot_20240603_162628](https://github.com/longhorn/infra/assets/104337648/b465f0eb-4732-46ec-9737-d56541bc1ff0)
