### PR TITLE
ci: save disk space by discarding old support bundles

### DIFF
--- a/jenkins-jobs/build-engine-test-images.yml
+++ b/jenkins-jobs/build-engine-test-images.yml
@@ -6,6 +6,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - bool:
           name: SEND_SLACK_NOTIFICATION

--- a/jenkins-jobs/cleanup-resources.yml
+++ b/jenkins-jobs/cleanup-resources.yml
@@ -6,6 +6,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/longhorn-argocd-test.yml
+++ b/jenkins-jobs/longhorn-argocd-test.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/longhorn-benchmark-test.yml
+++ b/jenkins-jobs/longhorn-benchmark-test.yml
@@ -6,6 +6,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
             name: TEST_SIZE

--- a/jenkins-jobs/longhorn-e2e-test.yml
+++ b/jenkins-jobs/longhorn-e2e-test.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - bool:
           name: SEND_SLACK_NOTIFICATION

--- a/jenkins-jobs/longhorn-fleet-test.yml
+++ b/jenkins-jobs/longhorn-fleet-test.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/longhorn-flux-test.yml
+++ b/jenkins-jobs/longhorn-flux-test.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/longhorn-helm-chart-test.yml
+++ b/jenkins-jobs/longhorn-helm-chart-test.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - bool:
           name: SEND_SLACK_NOTIFICATION

--- a/jenkins-jobs/longhorn-rancher-chart-test.yml
+++ b/jenkins-jobs/longhorn-rancher-chart-test.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/longhorn-storage-network-test.yml
+++ b/jenkins-jobs/longhorn-storage-network-test.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - bool:
           name: SEND_SLACK_NOTIFICATION

--- a/jenkins-jobs/longhorn-tests-regression.yml
+++ b/jenkins-jobs/longhorn-tests-regression.yml
@@ -6,6 +6,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - bool:
           name: SEND_SLACK_NOTIFICATION

--- a/jenkins-jobs/managed-k8s/longhorn-tests-aks.yml
+++ b/jenkins-jobs/managed-k8s/longhorn-tests-aks.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/managed-k8s/longhorn-tests-eks.yml
+++ b/jenkins-jobs/managed-k8s/longhorn-tests-eks.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/managed-k8s/longhorn-tests-gke.yml
+++ b/jenkins-jobs/managed-k8s/longhorn-tests-gke.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/master/oracle/longhorn-tests-oracle-amd64.yml
+++ b/jenkins-jobs/master/oracle/longhorn-tests-oracle-amd64.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/master/oracle/longhorn-upgrade-tests-oracle-amd64.yml
+++ b/jenkins-jobs/master/oracle/longhorn-upgrade-tests-oracle-amd64.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/master/rhel/longhorn-tests-rhel-amd64.yml
+++ b/jenkins-jobs/master/rhel/longhorn-tests-rhel-amd64.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/master/rhel/longhorn-tests-rhel-arm64.yml
+++ b/jenkins-jobs/master/rhel/longhorn-tests-rhel-arm64.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/master/rhel/longhorn-upgrade-tests-rhel-amd64.yml
+++ b/jenkins-jobs/master/rhel/longhorn-upgrade-tests-rhel-amd64.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/master/rhel/longhorn-upgrade-tests-rhel-arm64.yml
+++ b/jenkins-jobs/master/rhel/longhorn-upgrade-tests-rhel-arm64.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/master/rockylinux/longhorn-tests-rockylinux-amd64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-tests-rockylinux-amd64.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/master/rockylinux/longhorn-tests-rockylinux-arm64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-tests-rockylinux-arm64.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-amd64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-amd64.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-arm64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-arm64.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/master/sle-micro/longhorn-tests-sle-micro-amd64.yml
+++ b/jenkins-jobs/master/sle-micro/longhorn-tests-sle-micro-amd64.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/master/sle-micro/longhorn-tests-sle-micro-arm64.yml
+++ b/jenkins-jobs/master/sle-micro/longhorn-tests-sle-micro-arm64.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/master/sle-micro/longhorn-upgrade-tests-sle-micro-amd64.yml
+++ b/jenkins-jobs/master/sle-micro/longhorn-upgrade-tests-sle-micro-amd64.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/master/sle-micro/longhorn-upgrade-tests-sle-micro-arm64.yml
+++ b/jenkins-jobs/master/sle-micro/longhorn-upgrade-tests-sle-micro-arm64.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-amd64.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-arm64.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/master/sles/longhorn-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/sles/longhorn-tests-sles-amd64.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/master/sles/longhorn-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/sles/longhorn-tests-sles-arm64.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-amd64.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-arm64.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/master/ubuntu/longhorn-tests-ubuntu-amd64.yml
+++ b/jenkins-jobs/master/ubuntu/longhorn-tests-ubuntu-amd64.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/master/ubuntu/longhorn-tests-ubuntu-arm64.yml
+++ b/jenkins-jobs/master/ubuntu/longhorn-tests-ubuntu-arm64.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/master/ubuntu/longhorn-upgrade-tests-ubuntu-amd64.yml
+++ b/jenkins-jobs/master/ubuntu/longhorn-upgrade-tests-ubuntu-amd64.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/master/ubuntu/longhorn-upgrade-tests-ubuntu-arm64.yml
+++ b/jenkins-jobs/master/ubuntu/longhorn-upgrade-tests-ubuntu-arm64.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/mirror-csi-images.yml
+++ b/jenkins-jobs/mirror-csi-images.yml
@@ -6,6 +6,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/secscan.yml
+++ b/jenkins-jobs/secscan.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: TF_VAR_tf_workspace

--- a/jenkins-jobs/v1.4.x/longhorn-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.4.x/longhorn-tests-sles-amd64.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/v1.4.x/longhorn-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.4.x/longhorn-tests-sles-arm64.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/v1.4.x/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.4.x/longhorn-upgrade-tests-sles-amd64.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/v1.4.x/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.4.x/longhorn-upgrade-tests-sles-arm64.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/v1.5.x/longhorn-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.5.x/longhorn-tests-sles-amd64.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/v1.5.x/longhorn-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.5.x/longhorn-tests-sles-arm64.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/v1.5.x/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.5.x/longhorn-upgrade-tests-sles-amd64.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/v1.5.x/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.5.x/longhorn-upgrade-tests-sles-arm64.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/v1.6.x/longhorn-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.6.x/longhorn-tests-sles-amd64.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/v1.6.x/longhorn-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.6.x/longhorn-tests-sles-arm64.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/v1.6.x/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.6.x/longhorn-upgrade-tests-sles-amd64.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL

--- a/jenkins-jobs/v1.6.x/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.6.x/longhorn-upgrade-tests-sles-arm64.yml
@@ -5,6 +5,7 @@
     properties:
       - build-discarder:
           num-to-keep: 300
+          artifact-num-to-keep: 10
     parameters:
       - string:
           name: NOTIFY_SLACK_CHANNEL


### PR DESCRIPTION
ci: save disk space by discarding old support bundles

For https://github.com/longhorn/longhorn/issues/8693

Signed-off-by: Yang Chiu <yang.chiu@suse.com>