### PR TITLE
Update rockylinux arm64 `AWS_AVAILABILITY_ZONE`

### DIFF
--- a/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-amd64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-amd64.yml
@@ -76,8 +76,8 @@
           description: "aws region (e.g us-east-1), effective only when using aws as cloudprovider"
       - string:
           name: AWS_AVAILABILITY_ZONE
-          default: "us-east-1c"
-          description: "aws availability zone (e.g us-east-1c), effective only when using aws as cloudprovider, choosed based on AWS_REGION value"
+          default: "us-east-1a"
+          description: "aws availability zone (e.g us-east-1a), effective only when using aws as cloudprovider, choosed based on AWS_REGION value"
       - string:
           name: ARCH
           default: "amd64"

--- a/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-arm64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-arm64.yml
@@ -76,8 +76,8 @@
           description: "aws region (e.g us-east-1), effective only when using aws as cloudprovider"
       - string:
           name: AWS_AVAILABILITY_ZONE
-          default: "us-east-1c"
-          description: "aws availability zone (e.g us-east-1c), effective only when using aws as cloudprovider, choosed based on AWS_REGION value"
+          default: "us-east-1a"
+          description: "aws availability zone (e.g us-east-1a), effective only when using aws as cloudprovider, choosed based on AWS_REGION value"
       - string:
           name: ARCH
           default: "arm64"


### PR DESCRIPTION
https://ci.longhorn.io/job/public/job/master/job/rockylinux/job/arm64/job/longhorn-tests-rockylinux-arm64/32/console

```
Error: Error launching source instance: Unsupported: Your requested instance type (a1.2xlarge) is not supported in your requested Availability Zone (us-east-1c). Please retry your request by not specifying an Availability Zone or choosing us-east-1a, us-east-1b, us-east-1d.
	status code: 400, request id: cc24bd28-1885-4151-a532-c764f06e8bcb
```