### PR TITLE
ci: skip test_zone in eks

### DIFF
--- a/jenkins-jobs/managed-k8s/longhorn-tests-eks.yml
+++ b/jenkins-jobs/managed-k8s/longhorn-tests-eks.yml
@@ -49,7 +49,7 @@
           description: "custom longhorn-manager test image, will be used to run tests"
       - string:
           name: PYTEST_CUSTOM_OPTIONS
-          default: ""
+          default: "--ignore test_zone.py"
           description: "pytest custom options to run specific tests (e.g -k test_hosts)"
       - string:
           name: BACKUP_STORE_TYPE


### PR DESCRIPTION
ci: skip test_zone in eks because topology.kubernetes.io/zone is set to aws region (like us-east-1a) and cannot be modified even with label --overwrite command

Signed-off-by: Yang Chiu <yang.chiu@suse.com>