### PR TITLE
ci: update rockylinux aws avaiablility zone to us-east-1a which supports a1.2xlarge instance

### DIFF
--- a/jenkins-jobs/master/rockylinux/longhorn-tests-rockylinux-amd64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-tests-rockylinux-amd64.yml
@@ -76,7 +76,7 @@
           description: "aws region (e.g us-east-1), effective only when using aws as cloudprovider"
       - string:
           name: AWS_AVAILABILITY_ZONE
-          default: "us-east-1c"
+          default: "us-east-1a"
           description: "aws availability zone (e.g us-east-1c), effective only when using aws as cloudprovider, choosed based on AWS_REGION value"
       - string:
           name: ARCH

--- a/jenkins-jobs/master/rockylinux/longhorn-tests-rockylinux-arm64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-tests-rockylinux-arm64.yml
@@ -76,7 +76,7 @@
           description: "aws region (e.g us-east-1), effective only when using aws as cloudprovider"
       - string:
           name: AWS_AVAILABILITY_ZONE
-          default: "us-east-1c"
+          default: "us-east-1a"
           description: "aws availability zone (e.g us-east-1c), effective only when using aws as cloudprovider, choosed based on AWS_REGION value"
       - string:
           name: ARCH


### PR DESCRIPTION
ci: update rockylinux aws avaiablility zone to us-east-1a which supports a1.2xlarge instance

Signed-off-by: Yang Chiu <yang.chiu@suse.com>