### PR TITLE
ci: update sle-micro to larger instance type

### DIFF
--- a/jenkins-jobs/master/sle-micro/longhorn-tests-sle-micro-amd64.yml
+++ b/jenkins-jobs/master/sle-micro/longhorn-tests-sle-micro-amd64.yml
@@ -105,11 +105,11 @@
              for DISTRO=sle-micro, supported values: [6.0], default: [6.0]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t2.2xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t2.2xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/master/sle-micro/longhorn-tests-sle-micro-arm64.yml
+++ b/jenkins-jobs/master/sle-micro/longhorn-tests-sle-micro-arm64.yml
@@ -105,11 +105,11 @@
              for DISTRO=sle-micro, supported values: [6.0], default: [6.0]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "a1.4xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "a1.4xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/master/sle-micro/longhorn-upgrade-tests-sle-micro-amd64.yml
+++ b/jenkins-jobs/master/sle-micro/longhorn-upgrade-tests-sle-micro-amd64.yml
@@ -105,11 +105,11 @@
              for DISTRO=sle-micro, supported values: [6.0], default: [6.0]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t2.2xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "t2.xlarge"
+          default: "t2.2xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:

--- a/jenkins-jobs/master/sle-micro/longhorn-upgrade-tests-sle-micro-arm64.yml
+++ b/jenkins-jobs/master/sle-micro/longhorn-upgrade-tests-sle-micro-arm64.yml
@@ -105,11 +105,11 @@
              for DISTRO=sle-micro, supported values: [6.0], default: [6.0]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "a1.4xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "a1.4xlarge"
           description: "aws instance type for worker nodes"
     pipeline-scm:
       scm:


### PR DESCRIPTION
Longhorn test pod terminated while testing test_setting related test cases on sle-micro when using `t2.xlarge` and `a1.2xlarge`

```
test_settings.py::test_setting_concurrent_volume_backup_restore_limit_should_not_effect_dr_volumes[s3] PASSED
error: http2: server sent GOAWAY and closed the connection; LastStreamID=3, ErrCode=NO_ERROR, debug=""
++ kubectl get pod longhorn-test '-o=jsonpath={.status.containerStatuses[?(@.name=="longhorn-test")].state}'
++ grep -v terminated
```

- [AMD](https://ci.longhorn.io/job/public/job/master/job/sle-micro/job/amd64/job/longhorn-tests-sle-micro-amd64/175/)
- [AMD upgrade](https://ci.longhorn.io/job/public/job/master/job/sle-micro/job/amd64/job/longhorn-upgrade-tests-sle-micro-amd64/15/)
- [ARM](https://ci.longhorn.io/job/public/job/master/job/sle-micro/job/arm64/job/longhorn-tests-sle-micro-arm64/53/)
- [ARM upgrade](https://ci.longhorn.io/job/public/job/master/job/sle-micro/job/arm64/job/longhorn-upgrade-tests-sle-micro-arm64/15/)

Using `t2.2xlarge` and `a1.4xlarge` will not hit this issue, update the default value to saving test time, thank you.
- [AMD](https://ci.longhorn.io/job/public/job/master/job/sle-micro/job/amd64/job/longhorn-tests-sle-micro-amd64/178/)
- [AMD upgrade](https://ci.longhorn.io/job/public/job/master/job/sle-micro/job/amd64/job/longhorn-upgrade-tests-sle-micro-amd64/16/)
- [ARM](https://ci.longhorn.io/job/public/job/master/job/sle-micro/job/arm64/job/longhorn-tests-sle-micro-arm64/54/)
- [ARM upgrade
](https://ci.longhorn.io/job/public/job/master/job/sle-micro/job/arm64/job/longhorn-upgrade-tests-sle-micro-arm64/16/)