### PR TITLE
ci: use single backupstore on sle-micro pipeline to avoid test pod crash

### DIFF
--- a/jenkins-jobs/master/sle-micro/longhorn-tests-sle-micro-amd64.yml
+++ b/jenkins-jobs/master/sle-micro/longhorn-tests-sle-micro-amd64.yml
@@ -53,7 +53,7 @@
           description: "pytest custom options to run specific tests (e.g -k test_hosts)"
       - string:
           name: BACKUP_STORE_TYPE
-          default: "nfs-and-s3"
+          default: "s3"
           description: "The valid values for this field are 'nfs', 's3' and 'nfs-and-s3'"
       - string:
           name: TF_VAR_tf_workspace

--- a/jenkins-jobs/master/sle-micro/longhorn-tests-sle-micro-arm64.yml
+++ b/jenkins-jobs/master/sle-micro/longhorn-tests-sle-micro-arm64.yml
@@ -53,7 +53,7 @@
           description: "pytest custom options to run specific tests (e.g -k test_hosts)"
       - string:
           name: BACKUP_STORE_TYPE
-          default: "nfs-and-s3"
+          default: "nfs"
           description: "The valid values for this field are 'nfs', 's3' and 'nfs-and-s3'"
       - string:
           name: TF_VAR_tf_workspace

--- a/jenkins-jobs/master/sle-micro/longhorn-upgrade-tests-sle-micro-amd64.yml
+++ b/jenkins-jobs/master/sle-micro/longhorn-upgrade-tests-sle-micro-amd64.yml
@@ -53,7 +53,7 @@
           description: "pytest custom options to run specific tests (e.g -k test_hosts)"
       - string:
           name: BACKUP_STORE_TYPE
-          default: "nfs-and-s3"
+          default: "nfs"
           description: "The valid values for this field are 'nfs', 's3' and 'nfs-and-s3'"
       - string:
           name: TF_VAR_tf_workspace

--- a/jenkins-jobs/master/sle-micro/longhorn-upgrade-tests-sle-micro-arm64.yml
+++ b/jenkins-jobs/master/sle-micro/longhorn-upgrade-tests-sle-micro-arm64.yml
@@ -53,7 +53,7 @@
           description: "pytest custom options to run specific tests (e.g -k test_hosts)"
       - string:
           name: BACKUP_STORE_TYPE
-          default: "nfs-and-s3"
+          default: "s3"
           description: "The valid values for this field are 'nfs', 's3' and 'nfs-and-s3'"
       - string:
           name: TF_VAR_tf_workspace


### PR DESCRIPTION
Change the default backup store on the `sle-micro` pipeline to avoid using the default setting which causes test pod crash hours later.

test result and ref: https://github.com/longhorn/infra/pull/188#issuecomment-2277209000