### PR TITLE
ci: add custom ssh public key option to longhorn-e2e-test to allow team members to access test cluster

### DIFF
--- a/jenkins-jobs/longhorn-e2e-test.yml
+++ b/jenkins-jobs/longhorn-e2e-test.yml
@@ -139,6 +139,10 @@
           name: OUT_OF_CLUSTER
           default: false
           description: "whether to run test out of cluster (as a container) or in-cluster (as a pod)? (default: false)"
+      - string:
+          name: CUSTOM_SSH_PUBLIC_KEY
+          default: ""
+          description: "custom ssh public key for debugging"
     pipeline-scm:
       scm:
         - git:


### PR DESCRIPTION
ci: add custom ssh public key option to longhorn-e2e-test to allow team members to access test cluster

For https://github.com/longhorn/longhorn/issues/7307

Signed-off-by: Yang Chiu <yang.chiu@suse.com>