### PR TITLE
Enhance SLES Pipelines for k8s Version Compatibility

### DIFF
--- a/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-amd64.yml
@@ -92,11 +92,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.29.10+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.29.10+rke2r1)
+              for k3s: (default: v1.29.10+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/sles/longhorn-2-stage-upgrade-tests-sles-arm64.yml
@@ -92,11 +92,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.29.10+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.29.10+rke2r1)
+              for k3s: (default: v1.29.10+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-amd64.yml
@@ -88,11 +88,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.30.6+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.30.6+rke2r1)
+              for k3s: (default: v1.30.6+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/sles/longhorn-upgrade-tests-sles-arm64.yml
@@ -88,11 +88,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.30.6+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.30.6+rke2r1)
+              for k3s: (default: v1.30.6+k3s1)
       - string:
           name: DISTRO
           default: "sles"


### PR DESCRIPTION
Update SLES pipelines to ensure compatibility with all active Kubernetes versions.
- Enable E2E tests to run on rke2/k3s `v1.31.x`.
- Upgrade test support rke2/k3s `v1.30.x`.
- 2-stage upgrade test support rke2/k3s `v1.29.x`.

**Ref.**
![Screenshot_20241125_161306](https://github.com/user-attachments/assets/d3bf7001-5d8c-4c12-b488-fd38dd007b5f)
