### PR TITLE
ci: Update regression jobs rke2/k3s to v1.31.2

### DIFF
--- a/jenkins-jobs/longhorn-argocd-test.yml
+++ b/jenkins-jobs/longhorn-argocd-test.yml
@@ -69,11 +69,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.31.2+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/longhorn-benchmark-test.yml
+++ b/jenkins-jobs/longhorn-benchmark-test.yml
@@ -84,11 +84,11 @@
               for arm64, since rke2 doesn't support arm64, only k3s can be used
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+rke2r1"
+          default: "v1.31.2+rke2r1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
       - string:
           name: DISTRO
           default: "ubuntu"

--- a/jenkins-jobs/longhorn-e2e-test.yml
+++ b/jenkins-jobs/longhorn-e2e-test.yml
@@ -97,11 +97,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.31.2+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/longhorn-fleet-test.yml
+++ b/jenkins-jobs/longhorn-fleet-test.yml
@@ -69,11 +69,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.31.2+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/longhorn-flux-test.yml
+++ b/jenkins-jobs/longhorn-flux-test.yml
@@ -69,11 +69,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.31.2+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/longhorn-helm-chart-test.yml
+++ b/jenkins-jobs/longhorn-helm-chart-test.yml
@@ -97,11 +97,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.31.2+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/longhorn-storage-network-test.yml
+++ b/jenkins-jobs/longhorn-storage-network-test.yml
@@ -97,11 +97,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.31.2+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/longhorn-tests-regression.yml
+++ b/jenkins-jobs/longhorn-tests-regression.yml
@@ -255,11 +255,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.31.2+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
               for talos: (default: v1.30.0)
       - string:
           name: DISTRO

--- a/jenkins-jobs/master/oracle/longhorn-tests-oracle-amd64.yml
+++ b/jenkins-jobs/master/oracle/longhorn-tests-oracle-amd64.yml
@@ -88,11 +88,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.31.2+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
       - string:
           name: DISTRO
           default: "oracle"

--- a/jenkins-jobs/master/oracle/longhorn-upgrade-tests-oracle-amd64.yml
+++ b/jenkins-jobs/master/oracle/longhorn-upgrade-tests-oracle-amd64.yml
@@ -88,11 +88,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.31.2+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
       - string:
           name: DISTRO
           default: "oracle"

--- a/jenkins-jobs/master/rhel/longhorn-tests-rhel-amd64.yml
+++ b/jenkins-jobs/master/rhel/longhorn-tests-rhel-amd64.yml
@@ -88,11 +88,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.31.2+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
       - string:
           name: DISTRO
           default: "rhel"

--- a/jenkins-jobs/master/rhel/longhorn-tests-rhel-arm64.yml
+++ b/jenkins-jobs/master/rhel/longhorn-tests-rhel-arm64.yml
@@ -88,11 +88,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.31.2+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
       - string:
           name: DISTRO
           default: "rhel"

--- a/jenkins-jobs/master/rhel/longhorn-upgrade-tests-rhel-amd64.yml
+++ b/jenkins-jobs/master/rhel/longhorn-upgrade-tests-rhel-amd64.yml
@@ -88,11 +88,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.31.2+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
       - string:
           name: DISTRO
           default: "rhel"

--- a/jenkins-jobs/master/rhel/longhorn-upgrade-tests-rhel-arm64.yml
+++ b/jenkins-jobs/master/rhel/longhorn-upgrade-tests-rhel-arm64.yml
@@ -88,11 +88,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.31.2+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
       - string:
           name: DISTRO
           default: "rhel"

--- a/jenkins-jobs/master/rockylinux/longhorn-tests-rockylinux-amd64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-tests-rockylinux-amd64.yml
@@ -88,11 +88,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.31.2+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
       - string:
           name: DISTRO
           default: "rockylinux"

--- a/jenkins-jobs/master/rockylinux/longhorn-tests-rockylinux-arm64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-tests-rockylinux-arm64.yml
@@ -88,11 +88,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.31.2+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
       - string:
           name: DISTRO
           default: "rockylinux"

--- a/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-amd64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-amd64.yml
@@ -88,11 +88,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.31.2+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
       - string:
           name: DISTRO
           default: "rockylinux"

--- a/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-arm64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-arm64.yml
@@ -88,11 +88,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.31.2+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
       - string:
           name: DISTRO
           default: "rockylinux"

--- a/jenkins-jobs/master/sle-micro/longhorn-tests-sle-micro-amd64.yml
+++ b/jenkins-jobs/master/sle-micro/longhorn-tests-sle-micro-amd64.yml
@@ -88,11 +88,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.31.2+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
       - string:
           name: DISTRO
           default: "sle-micro"

--- a/jenkins-jobs/master/sle-micro/longhorn-tests-sle-micro-arm64.yml
+++ b/jenkins-jobs/master/sle-micro/longhorn-tests-sle-micro-arm64.yml
@@ -88,11 +88,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.31.2+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
       - string:
           name: DISTRO
           default: "sle-micro"

--- a/jenkins-jobs/master/sle-micro/longhorn-upgrade-tests-sle-micro-amd64.yml
+++ b/jenkins-jobs/master/sle-micro/longhorn-upgrade-tests-sle-micro-amd64.yml
@@ -88,11 +88,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.31.2+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
       - string:
           name: DISTRO
           default: "sle-micro"

--- a/jenkins-jobs/master/sle-micro/longhorn-upgrade-tests-sle-micro-arm64.yml
+++ b/jenkins-jobs/master/sle-micro/longhorn-upgrade-tests-sle-micro-arm64.yml
@@ -88,11 +88,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.31.2+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
       - string:
           name: DISTRO
           default: "sle-micro"

--- a/jenkins-jobs/master/sles/longhorn-tests-sles-amd64.yml
+++ b/jenkins-jobs/master/sles/longhorn-tests-sles-amd64.yml
@@ -88,11 +88,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.31.2+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/master/sles/longhorn-tests-sles-arm64.yml
+++ b/jenkins-jobs/master/sles/longhorn-tests-sles-arm64.yml
@@ -88,11 +88,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.31.2+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/master/talos/longhorn-tests-talos-amd64.yml
+++ b/jenkins-jobs/master/talos/longhorn-tests-talos-amd64.yml
@@ -91,8 +91,8 @@
           default: "v1.30.0"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
               for talos: (default: v1.30.0)
       - string:
           name: DISTRO

--- a/jenkins-jobs/master/talos/longhorn-upgrade-tests-talos-amd64.yml
+++ b/jenkins-jobs/master/talos/longhorn-upgrade-tests-talos-amd64.yml
@@ -91,8 +91,8 @@
           default: "v1.30.0"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
               for talos: (default: v1.30.0)
       - string:
           name: DISTRO

--- a/jenkins-jobs/master/ubuntu/longhorn-tests-ubuntu-amd64.yml
+++ b/jenkins-jobs/master/ubuntu/longhorn-tests-ubuntu-amd64.yml
@@ -88,11 +88,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.31.2+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
       - string:
           name: DISTRO
           default: "ubuntu"

--- a/jenkins-jobs/master/ubuntu/longhorn-tests-ubuntu-arm64.yml
+++ b/jenkins-jobs/master/ubuntu/longhorn-tests-ubuntu-arm64.yml
@@ -88,11 +88,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.31.2+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
       - string:
           name: DISTRO
           default: "ubuntu"

--- a/jenkins-jobs/master/ubuntu/longhorn-upgrade-tests-ubuntu-amd64.yml
+++ b/jenkins-jobs/master/ubuntu/longhorn-upgrade-tests-ubuntu-amd64.yml
@@ -88,11 +88,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.31.2+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
       - string:
           name: DISTRO
           default: "ubuntu"

--- a/jenkins-jobs/master/ubuntu/longhorn-upgrade-tests-ubuntu-arm64.yml
+++ b/jenkins-jobs/master/ubuntu/longhorn-upgrade-tests-ubuntu-arm64.yml
@@ -88,11 +88,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.31.2+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
       - string:
           name: DISTRO
           default: "ubuntu"

--- a/jenkins-jobs/v1.6.x/longhorn-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.6.x/longhorn-tests-sles-amd64.yml
@@ -88,11 +88,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.31.2+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/v1.6.x/longhorn-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.6.x/longhorn-tests-sles-arm64.yml
@@ -88,11 +88,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.31.2+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/v1.6.x/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.6.x/longhorn-upgrade-tests-sles-amd64.yml
@@ -92,11 +92,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.31.2+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/v1.6.x/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.6.x/longhorn-upgrade-tests-sles-arm64.yml
@@ -92,11 +92,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.31.2+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/v1.7.x/longhorn-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.7.x/longhorn-tests-sles-amd64.yml
@@ -88,11 +88,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.31.2+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/v1.7.x/longhorn-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.7.x/longhorn-tests-sles-arm64.yml
@@ -88,11 +88,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.31.2+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/v1.7.x/longhorn-upgrade-tests-sles-amd64.yml
+++ b/jenkins-jobs/v1.7.x/longhorn-upgrade-tests-sles-amd64.yml
@@ -92,11 +92,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.31.2+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
       - string:
           name: DISTRO
           default: "sles"

--- a/jenkins-jobs/v1.7.x/longhorn-upgrade-tests-sles-arm64.yml
+++ b/jenkins-jobs/v1.7.x/longhorn-upgrade-tests-sles-arm64.yml
@@ -92,11 +92,11 @@
           description: "kubernetes distro version to install [rke2, k3s] (default: k3s)"
       - string:
           name: K8S_DISTRO_VERSION
-          default: "v1.31.1+k3s1"
+          default: "v1.31.2+k3s1"
           description: |
               kubernetes version that will be deployed
-              for rke2: (default: v1.31.1+rke2r1)
-              for k3s: (default: v1.31.1+k3s1)
+              for rke2: (default: v1.31.2+rke2r1)
+              for k3s: (default: v1.31.2+k3s1)
       - string:
           name: DISTRO
           default: "sles"


### PR DESCRIPTION
https://github.com/longhorn/longhorn/issues/9684

v1.31.2+k3s1 test report: https://ci.longhorn.io/job/private/job/longhorn-tests-regression/7720/

v1.31.2+rke2r1 test report : https://ci.longhorn.io/job/private/job/longhorn-tests-regression/7721/