### PR TITLE
ci: Bump OS distro version for Longhorn v1.8.0

### DIFF
--- a/jenkins-jobs/master/oracle/longhorn-tests-oracle-amd64.yml
+++ b/jenkins-jobs/master/oracle/longhorn-tests-oracle-amd64.yml
@@ -99,10 +99,10 @@
           description: "Linux distro used to install on created instances, supported values: [ubuntu, rhel, sles, centos, oracle, rockylinux]"
       - string:
           name: DISTRO_VERSION
-          default: "9.3"
+          default: "9.4"
           description: |
              Linux distro version to install on created instances, choosed based on DISTRO values
-             for DISTRO=oracle, supported values: [9.3], default: [9.3]
+             for DISTRO=oracle, supported values: [9.3, 9.4], default: [9.4]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
           default: "t2.xlarge"

--- a/jenkins-jobs/master/oracle/longhorn-upgrade-tests-oracle-amd64.yml
+++ b/jenkins-jobs/master/oracle/longhorn-upgrade-tests-oracle-amd64.yml
@@ -99,10 +99,10 @@
           description: "Linux distro used to install on created instances, supported values: [ubuntu, rhel, sles, centos, oracle, rockylinux]"
       - string:
           name: DISTRO_VERSION
-          default: "9.3"
+          default: "9.4"
           description: |
              Linux distro version to install on created instances, choosed based on DISTRO values
-             for DISTRO=oracle, supported values: [9.3], default: [9.3]
+             for DISTRO=oracle, supported values: [9.3, 9.4], default: [9.4]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
           default: "t2.xlarge"

--- a/jenkins-jobs/master/rhel/longhorn-tests-rhel-amd64.yml
+++ b/jenkins-jobs/master/rhel/longhorn-tests-rhel-amd64.yml
@@ -99,10 +99,10 @@
           description: "Linux distro used to install on created instances, supported values: [ubuntu, rhel, sles, centos, oracle, rockylinux]"
       - string:
           name: DISTRO_VERSION
-          default: "9.3.0"
+          default: "9.5.0"
           description: |
              Linux distro version to install on created instances, choosed based on DISTRO values
-             for DISTRO=rhel, supported values: [9.3.0], default: [9.3.0]
+             for DISTRO=rhel, supported values: [9.3.0, 9.4.0, 9.5.0], default: [9.5.0]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
           default: "t2.xlarge"

--- a/jenkins-jobs/master/rhel/longhorn-tests-rhel-arm64.yml
+++ b/jenkins-jobs/master/rhel/longhorn-tests-rhel-arm64.yml
@@ -99,17 +99,17 @@
           description: "Linux distro used to install on created instances, supported values: [ubuntu, rhel, sles, centos, oracle, rockylinux]" 
       - string:
           name: DISTRO_VERSION
-          default: "9.3.0"
+          default: "9.5.0"
           description: |
              Linux distro version to install on created instances, choosed based on DISTRO values
-             for DISTRO=rhel, supported values: [9.3.0], default: [9.3.0]
+             for DISTRO=rhel, supported values: [9.3.0, 9.4.0, 9.5.0], default: [9.5.0]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for worker nodes"
       - choice:
           name: SELINUX_MODE

--- a/jenkins-jobs/master/rhel/longhorn-upgrade-tests-rhel-amd64.yml
+++ b/jenkins-jobs/master/rhel/longhorn-upgrade-tests-rhel-amd64.yml
@@ -99,10 +99,10 @@
           description: "Linux distro used to install on created instances, supported values: [ubuntu, rhel, sles, centos, oracle, rockylinux]"
       - string:
           name: DISTRO_VERSION
-          default: "9.3.0"
+          default: "9.5.0"
           description: |
              Linux distro version to install on created instances, choosed based on DISTRO values
-             for DISTRO=rhel, supported values: [9.3.0], default: [9.3.0]
+             for DISTRO=rhel, supported values: [9.3.0, 9.4.0, 9.5.0], default: [9.5.0]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
           default: "t2.xlarge"

--- a/jenkins-jobs/master/rhel/longhorn-upgrade-tests-rhel-arm64.yml
+++ b/jenkins-jobs/master/rhel/longhorn-upgrade-tests-rhel-arm64.yml
@@ -99,17 +99,17 @@
           description: "Linux distro used to install on created instances, supported values: [ubuntu, rhel, sles, centos, oracle, rockylinux]"
       - string:
           name: DISTRO_VERSION
-          default: "9.3.0"
+          default: "9.5.0"
           description: |
              Linux distro version to install on created instances, choosed based on DISTRO values
-             for DISTRO=rhel, supported values: [9.3.0], default: [9.3.0]
+             for DISTRO=rhel, supported values: [9.3.0, 9.4.0, 9.5.0], default: [9.5.0]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for worker nodes"
       - choice:
           name: SELINUX_MODE

--- a/jenkins-jobs/master/rockylinux/longhorn-tests-rockylinux-amd64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-tests-rockylinux-amd64.yml
@@ -99,10 +99,10 @@
           description: "Linux distro used to install on created instances, supported values: [ubuntu, rhel, sles, centos, oracle, rockylinux]"
       - string:
           name: DISTRO_VERSION
-          default: "9.3"
+          default: "9.5"
           description: |
              Linux distro version to install on created instances, choosed based on DISTRO values
-             for DISTRO=rockylinux, supported values: [9.3], default: [9.3]
+             for DISTRO=rockylinux, supported values: [9.3, 9.4, 9.5], default: [9.5]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
           default: "t2.xlarge"

--- a/jenkins-jobs/master/rockylinux/longhorn-tests-rockylinux-arm64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-tests-rockylinux-arm64.yml
@@ -99,17 +99,17 @@
           description: "Linux distro used to install on created instances, supported values: [ubuntu, rhel, sles, centos, oracle, rockylinux]"
       - string:
           name: DISTRO_VERSION
-          default: "9.3"
+          default: "9.5"
           description: |
              Linux distro version to install on created instances, choosed based on DISTRO values
-             for DISTRO=rockylinux, supported values: [9.3], default: [9.3]
+             for DISTRO=rockylinux, supported values: [9.3, 9.4, 9.5], default: [9.5]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for worker nodes"
       - choice:
           name: SELINUX_MODE

--- a/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-amd64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-amd64.yml
@@ -99,10 +99,10 @@
           description: "Linux distro used to install on created instances, supported values: [ubuntu, rhel, sles, centos, oracle, rockylinux]"
       - string:
           name: DISTRO_VERSION
-          default: "9.3"
+          default: "9.5"
           description: |
              Linux distro version to install on created instances, choosed based on DISTRO values
-             for DISTRO=rockylinux, supported values: [9.3], default: [9.3]
+             for DISTRO=rockylinux, supported values: [9.3, 9.4, 9.5], default: [9.5]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
           default: "t2.xlarge"

--- a/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-arm64.yml
+++ b/jenkins-jobs/master/rockylinux/longhorn-upgrade-tests-rockylinux-arm64.yml
@@ -99,17 +99,17 @@
           description: "Linux distro used to install on created instances, supported values: [ubuntu, rhel, sles, centos, oracle, rockylinux]"
       - string:
           name: DISTRO_VERSION
-          default: "9.3"
+          default: "9.5"
           description: |
              Linux distro version to install on created instances, choosed based on DISTRO values
-             for DISTRO=rockylinux, supported values: [9.3], default: [9.3]
+             for DISTRO=rockylinux, supported values: [9.3, 9.4, 9.5], default: [9.5]
       - string:
           name: CONTROLPLANE_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for controlplane nodes"
       - string:
           name: WORKER_INSTANCE_TYPE
-          default: "a1.2xlarge"
+          default: "t4g.xlarge"
           description: "aws instance type for worker nodes"
       - choice:
           name: SELINUX_MODE


### PR DESCRIPTION
https://github.com/longhorn/longhorn/issues/9879

* Rockylinux, `9.5`
  - [x] amd64: https://ci.longhorn.io/job/public/job/master/job/rockylinux/job/amd64/job/longhorn-tests-rockylinux-amd64/44/
  - [x] arm64: https://ci.longhorn.io/job/public/job/master/job/rockylinux/job/arm64/job/longhorn-tests-rockylinux-arm64/69/
* RHEL `9.5.0`
  - [x] amd64: https://ci.longhorn.io/job/public/job/master/job/rhel/job/amd64/job/longhorn-tests-rhel-amd64/182/ 
  - [x] arm64: https://ci.longhorn.io/job/public/job/master/job/rhel/job/arm64/job/longhorn-tests-rhel-arm64/100/
* Oracle `9.4`
  - [x] amd64: https://ci.longhorn.io/job/public/job/master/job/oracle/job/amd64/job/longhorn-tests-oracle-amd64/38