### PR TITLE
ci: update BACKUP_STORE_TYPE description for cifs and azurite

### DIFF
--- a/jenkins-jobs/longhorn-e2e-test.yml
+++ b/jenkins-jobs/longhorn-e2e-test.yml
@@ -66,7 +66,7 @@
       - string:
           name: BACKUP_STORE_TYPE
           default: "s3"
-          description: "The valid values for this field are 'nfs', 's3'"
+          description: "The valid values for this field are 'nfs', 's3', 'cifs' and 'azurite', any other value provided will use all those four backupstores."
       - string:
           name: LONGHORN_STABLE_VERSION
           default: "v1.5.1"

--- a/jenkins-jobs/longhorn-tests-regression.yml
+++ b/jenkins-jobs/longhorn-tests-regression.yml
@@ -73,8 +73,8 @@
           description: "run longhorn upgrade test, then run longhorn test suite"
       - string:
           name: BACKUP_STORE_TYPE
-          default: "nfs-and-s3"
-          description: "The valid values for this field are 'nfs', 's3' and 'nfs-and-s3'"
+          default: "s3"
+          description: "The valid values for this field are 'nfs', 's3', 'cifs' and 'azurite', any other value provided will use all those four backupstores."
       - string:
           name: LONGHORN_STABLE_VERSION
           default: "v1.7.2"


### PR DESCRIPTION
ci: update `BACKUP_STORE_TYPE` description for `cifs` and `azurite` in longhorn-tests-regression.yml and longhorn-e2e-test.yml
 
https://github.com/longhorn/longhorn/issues/9699
https://github.com/longhorn/longhorn-tests/pull/2155