### PR TITLE
Support v2 volume on daily regression

### DIFF
--- a/jenkins-jobs/longhorn-tests-regression.yml
+++ b/jenkins-jobs/longhorn-tests-regression.yml
@@ -303,6 +303,10 @@
           name: PUBLIC_WORKER_NODE
           default: false
           description: "whether to assign public ip for worker nodes"
+      - bool:
+          name: RUN_V2_TEST
+          default: false
+          description: "use v2 volume for testing"
     pipeline-scm:
       scm:
         - git:


### PR DESCRIPTION
For longhorn/longhorn#[2170](https://github.com/longhorn/longhorn-tests/pull/2170)

Enable `RUN_V2_TEST` on Jenkins and use pytest mark `-m v2_volume_test` for using v2 volume in regression test. Some test case not support v2 volume and logged [here](https://github.com/longhorn/longhorn/issues/9760)